### PR TITLE
fix: label the resize handle and quieten false a11y warnings

### DIFF
--- a/src/web/app/components/MarkdownLink.tsx
+++ b/src/web/app/components/MarkdownLink.tsx
@@ -72,10 +72,8 @@ export const MarkdownLink: FC<MarkdownLinkProps> = ({ href, children }) => {
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
-            role="img"
-            aria-labelledby="preview-icon-title"
+            aria-hidden="true"
           >
-            <title id="preview-icon-title">Preview</title>
             <path
               strokeLinecap="round"
               strokeLinejoin="round"

--- a/src/web/app/projects/[projectId]/components/chatForm/CommandCompletion.tsx
+++ b/src/web/app/projects/[projectId]/components/chatForm/CommandCompletion.tsx
@@ -226,6 +226,7 @@ export const CommandCompletion = forwardRef<CommandCompletionRef, CommandComplet
                         )}
                         onClick={() => handleCommandSelect(command)}
                         onMouseEnter={() => setSelectedIndex(index)}
+                        // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- <option> is only valid inside <select>; this is a custom listbox
                         role="option"
                         tabIndex={-1}
                         aria-selected={index === selectedIndex}

--- a/src/web/app/projects/[projectId]/components/chatForm/FileCompletion.tsx
+++ b/src/web/app/projects/[projectId]/components/chatForm/FileCompletion.tsx
@@ -281,6 +281,7 @@ export const FileCompletion = forwardRef<FileCompletionRef, FileCompletionProps>
                         )}
                         onClick={() => handleEntrySelect(entry, entry.type === "file")}
                         onMouseEnter={() => setSelectedIndex(index)}
+                        // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- <option> is only valid inside <select>; this is a custom listbox
                         role="option"
                         tabIndex={-1}
                         aria-selected={index === selectedIndex}

--- a/src/web/components/ResizableSidebar.tsx
+++ b/src/web/components/ResizableSidebar.tsx
@@ -95,7 +95,9 @@ export const ResizableSidebar: FC<ResizableSidebarProps> = ({ children, classNam
       {/* Resize handle - only show when content is visible */}
       {isLeftPanelOpen && (
         <div
+          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- a focusable splitter, which <hr> cannot be
           role="separator"
+          aria-label="Resize sidebar"
           aria-orientation="vertical"
           aria-valuemin={0}
           aria-valuemax={50}


### PR DESCRIPTION
## What this changes

- The sidebar resize handle now has an accessible name (`aria-label="Resize sidebar"`), which it was missing.
- The preview icon is marked decorative: the anchor around it already carries `aria-label="Preview in browser"`, so the SVG was announcing itself twice.
- Two `prefer-tag-over-role` warnings are suppressed with a reason. They are wrong for these widgets: `<option>` is only valid inside `<select>` (these are custom listboxes), and `<hr>` cannot be a focusable splitter.

## Why

The oxlint 1.76 bump surfaced these. Lint is now clean with no warnings.

## Checklist

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` (1001) pass
- [x] No `as` casting added
- [x] Behaviour unchanged