### PR TITLE
feat: publish container images and npm releases from a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node & pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+  container:
+    name: container
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # arm64 is here for the Raspberry Pi and Apple Silicon crowd.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  npm:
+    name: npm
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      # Required for npm provenance.
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node & pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Publish
+        run: pnpm publish --provenance --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-release:
+    name: github release
+    needs: [container, npm]
+    # A missing npm token should not swallow the release notes.
+    if: always() && needs.container.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node & pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Publish release notes
+        run: pnpm dlx changelogithub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:22-slim AS base
+FROM node:24-slim AS base
 ENV PNPM_HOME=/usr/local/share/pnpm
 ENV PATH=${PNPM_HOME}:${PATH}
 RUN corepack enable pnpm && apt-get update && apt-get install -y git openssh-client && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/WildChildForLife/lantern/actions/workflows/ci.yml/badge.svg)](https://github.com/WildChildForLife/lantern/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/WildChildForLife/lantern/actions/workflows/codeql.yml/badge.svg)](https://github.com/WildChildForLife/lantern/actions/workflows/codeql.yml)
+[![npm](https://img.shields.io/npm/v/lantern-ccv.svg)](https://www.npmjs.com/package/lantern-ccv)
+[![Container](https://img.shields.io/badge/ghcr.io-lantern-blue.svg)](https://github.com/WildChildForLife/lantern/pkgs/container/lantern)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24-brightgreen.svg)](https://nodejs.org)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -41,7 +43,41 @@ searchable list of everything, and a board view of the lot.
 
 ## Install
 
-Lantern is not on npm yet. Run it from source:
+### Docker
+
+```bash
+docker run -d --name lantern \
+  -p 127.0.0.1:3400:3400 \
+  -v "$HOME/.claude:/root/.claude:ro" \
+  -v lantern_cache:/root/.claude-code-viewer \
+  ghcr.io/wildchildforlife/lantern:latest
+```
+
+Or with Compose, which is the same thing plus a password:
+
+```bash
+curl -O https://raw.githubusercontent.com/WildChildForLife/lantern/main/docker-compose.yml
+echo "CCV_PASSWORD=pick-something" > .env
+docker compose up -d
+```
+
+Images are published for `linux/amd64` and `linux/arm64`, so a Raspberry Pi or an Apple Silicon
+machine works the same way.
+
+### npm
+
+```bash
+npx lantern-ccv --port 3400
+```
+
+Or install it properly:
+
+```bash
+npm install -g lantern-ccv
+lantern --port 3400
+```
+
+### From source
 
 ```bash
 git clone https://github.com/WildChildForLife/lantern.git
@@ -53,7 +89,8 @@ node dist/main.js --port 3400
 
 Then open <http://localhost:3400>.
 
-> **Requirements:** Node.js 24 or newer, pnpm, and Claude Code installed and signed in.
+> **Requirements:** Node.js 24 or newer for the npm and source installs. Claude Code itself must be
+> installed and signed in for the optional AI topic naming; everything else works without it.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,38 @@
 services:
-  app:
+  lantern:
+    image: ghcr.io/wildchildforlife/lantern:latest
+    environment:
+      CCV_ENV: production
+      PORT: 3400
+      # Strongly recommended: Lantern ships an in-app terminal and this
+      # container publishes a port. Put it in a .env file next to this one.
+      CCV_PASSWORD: "${CCV_PASSWORD:-}"
+    ports:
+      # Bound to loopback. Change to "3400:3400" only behind a VPN or a proxy.
+      - "127.0.0.1:3400:3400"
+    volumes:
+      # Your session logs. Read-only, because Lantern only ever reads them.
+      - "${HOME}/.claude:/root/.claude:ro"
+      # Its own cache, kept out of your home directory.
+      - lantern_cache:/root/.claude-code-viewer
+    restart: unless-stopped
+    init: true
+
+  # The same service built from this checkout: docker compose --profile dev up --build lantern-dev
+  lantern-dev:
+    profiles: ["dev"]
     build: .
     environment:
       CCV_ENV: production
       PORT: 3400
-      CCV_PASSWORD: "${CCV_PASSWORD}"
-      ANTHROPIC_BASE_URL: "${ANTHROPIC_BASE_URL}"
-      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
-      ANTHROPIC_AUTH_TOKEN: "${ANTHROPIC_AUTH_TOKEN}"
+      CCV_PASSWORD: "${CCV_PASSWORD:-}"
     ports:
-      - "3400:3400"
+      - "127.0.0.1:3400:3400"
     volumes:
-      # - claude_home:/root/.claude
-      - workspace:/root/workspace
+      - "${HOME}/.claude:/root/.claude:ro"
+      - lantern_cache:/root/.claude-code-viewer
     restart: unless-stopped
     init: true
 
 volumes:
-  claude_home:
-  workspace:
+  lantern_cache:


### PR DESCRIPTION
## What this changes

Installing Lantern meant cloning and building. After this, a `v*` tag publishes everything:

- **Container** — multi-arch (`linux/amd64`, `linux/arm64`) image to `ghcr.io/wildchildforlife/lantern`, using `GITHUB_TOKEN`, no secrets to configure.
- **npm** — `lantern-ccv` published with provenance (`id-token: write`).
- **Release notes** — drafted with `changelogithub`, which was already a dependency.

Every job runs behind a `verify` job (lint, typecheck, tests), so a broken tag publishes nothing.

## Also

- **Dockerfile moves to Node 24.** It pinned `node:22-slim` while `engines` requires `>=24` — the image was building against an unsupported runtime.
- **Compose rewritten** to run the published image, mount `~/.claude` read-only, bind to loopback and take a password, with a `dev` profile for local builds.
- README documents Docker, npm and source installs, plus npm and container badges.

## One manual step

npm publishing needs credentials. Either add an `NPM_TOKEN` secret, or configure trusted publishing for `lantern-ccv` on npmjs.com (preferred — no token to rotate). Until then the `npm` job fails and the container and release-notes jobs still succeed.

## Checklist

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass
- [x] No `as` casting added