### PR TITLE
docs: complete the README's flags, source roots and platform caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ searchable list of everything, and a board view of the lot.
   <img src="docs/screenshots/topics.jpg" alt="Topics grouped by subject, each with an icon and a conversation count" width="100%">
 </p>
 
+## Contents
+
+- [What it does](#what-it-does)
+- [Install](#install) · [Docker](#docker) · [npm](#npm) · [From source](#from-source)
+- [Usage](#usage) · [Options](#options) · [Security](#security)
+- [Reading other agent CLIs](#reading-other-agent-clis)
+- [Reading logs from more than one machine](#reading-logs-from-more-than-one-machine)
+- [How grouping works](#how-grouping-works)
+- [Development](#development) · [Contributing](#contributing) · [Support](#support)
+- [Privacy](#privacy) · [Licence](#licence)
+
 ## What it does
 
 - **Topics instead of folders.** Conversations are clustered by subject, each topic with its own icon,
@@ -67,8 +78,13 @@ echo "LANTERN_PASSWORD=pick-something" > .env
 docker compose up -d
 ```
 
+That mounts Claude Code's logs only. To read Codex or opencode as well, see
+[Reading other agent CLIs](#reading-other-agent-clis).
+
 Images are published for `linux/amd64` and `linux/arm64`, so a Raspberry Pi or an Apple Silicon
-machine works the same way.
+machine works the same way — with one exception: the in-app terminal is unavailable on the `arm64`
+image, because the PTY library it uses publishes no `linux/arm64` build. Everything else is identical,
+and Lantern says so in its startup log rather than failing.
 
 ### npm
 
@@ -104,27 +120,71 @@ Then open <http://localhost:3400>.
 node dist/main.js [options]
 ```
 
-| Option                      | Environment                 | Description                                               | Default     |
-| --------------------------- | --------------------------- | --------------------------------------------------------- | ----------- |
-| `-p, --port <port>`         | `PORT`                      | Port to listen on                                         | `3000`      |
-| `-h, --hostname <hostname>` | `HOSTNAME`                  | Hostname to bind                                          | `localhost` |
-| `-P, --password <password>` | `LANTERN_PASSWORD`          | Require a password. **Set this if you bind to `0.0.0.0`** | (none)      |
-| `--claude-dir <path>`       | `LANTERN_CLAUDE_DIR`        | Path to the Claude directory to read                      | `~/.claude` |
-| `-e, --executable <path>`   | `LANTERN_CLAUDE_EXECUTABLE` | Path to the `claude` executable                           | auto        |
-| `--terminal-disabled`       | `LANTERN_TERMINAL_DISABLED` | Turn off the in-app terminal                              | enabled     |
-| `--terminal-shell <path>`   | `LANTERN_TERMINAL_SHELL`    | Shell used by terminal sessions                           | login shell |
-| `--api-only`                | `LANTERN_API_ONLY`          | Serve the API without the web UI                          | off         |
-| `-v, --verbose`             | `LANTERN_VERBOSE`           | Verbose debug logging                                     | off         |
-| `--source <id>`             | `LANTERN_SOURCES`           | Agent CLI to read; repeat for more. Scopes one run        | stored      |
+### Options
 
-> **Security:** Lantern ships an in-app terminal. Binding to anything other than `localhost` without
+| Option                      | Environment                     | Description                                                 | Default     |
+| --------------------------- | ------------------------------- | ----------------------------------------------------------- | ----------- |
+| `-p, --port <port>`         | `PORT`                          | Port to listen on                                           | `3000`      |
+| `-h, --hostname <hostname>` | `HOSTNAME`                      | Hostname to bind                                            | `localhost` |
+| `-P, --password <password>` | `LANTERN_PASSWORD`              | Require a password. **Set this if you bind to `0.0.0.0`**   | (none)      |
+| `--claude-dir <path>`       | `LANTERN_CLAUDE_DIR`            | Path to the Claude directory to read                        | `~/.claude` |
+| `-e, --executable <path>`   | `LANTERN_CLAUDE_EXECUTABLE`     | Path to the `claude` executable                             | auto        |
+| `--terminal-disabled`       | `LANTERN_TERMINAL_DISABLED`     | Turn off the in-app terminal                                | enabled     |
+| `--terminal-shell <path>`   | `LANTERN_TERMINAL_SHELL`        | Shell used by terminal sessions                             | login shell |
+| `--terminal-unrestricted`   | `LANTERN_TERMINAL_UNRESTRICTED` | Drop the restricted shell flags from bash terminal sessions | restricted  |
+| `--api-only`                | `LANTERN_API_ONLY`              | Serve the API without the web UI                            | off         |
+| `-v, --verbose`             | `LANTERN_VERBOSE`               | Verbose debug logging                                       | off         |
+| `--source <id>`             | `LANTERN_SOURCES`               | Agent CLI to read; repeat for more. Scopes one run          | stored      |
+
+Valid `--source` ids are `claude-code`, `codex` and `opencode`. Repeat the flag for more than one
+(`--source claude-code --source codex`), or set `LANTERN_SOURCES` to a comma-separated list. Passing it
+scopes a single run without changing what is stored in settings.
+
+Flag-style environment variables are on for `1` or `true` and off otherwise.
+
+### Security
+
+> Lantern ships an in-app terminal. Binding to anything other than `localhost` without
 > `--password` hands a remote shell to whoever finds the port. Use `--terminal-disabled` and a
-> password, or keep it behind a VPN such as Tailscale.
+> password, or keep it behind a VPN such as Tailscale. `--terminal-unrestricted` removes the guard
+> rails from bash sessions, so treat it as widening that same hole.
+
+The threat model, what a running instance exposes, and how to report a vulnerability privately are all
+in [SECURITY.md](SECURITY.md). Please use
+[GitHub Security Advisories](https://github.com/WildChildForLife/lantern/security/advisories/new)
+rather than a public issue.
 
 Lantern keeps its cache, push keys and schedules in `~/.lantern/`. Deleting that directory costs
 nothing but a rebuild on the next start.
 
-### Reading logs from more than one machine
+## Reading other agent CLIs
+
+Codex and opencode are read from wherever those CLIs themselves keep their history, so pointing Lantern
+at them is the same gesture as pointing the CLI at them:
+
+| Source        | Default location          | Moved by                              |
+| ------------- | ------------------------- | ------------------------------------- |
+| `claude-code` | `~/.claude`               | `--claude-dir` / `LANTERN_CLAUDE_DIR` |
+| `codex`       | `~/.codex`                | `CODEX_HOME`                          |
+| `opencode`    | `~/.local/share/opencode` | `XDG_DATA_HOME`                       |
+
+Enable the ones you want in settings, or scope a single run with `--source`.
+
+In Docker each one needs its own mount, since only `~/.claude` is mounted by default:
+
+```bash
+docker run -d --name lantern \
+  -p 127.0.0.1:3400:3400 \
+  -v "$HOME/.claude:/root/.claude:ro" \
+  -v "$HOME/.codex:/root/.codex:ro" \
+  -v "$HOME/.local/share/opencode:/root/.local/share/opencode:ro" \
+  -v lantern_cache:/root/.lantern \
+  ghcr.io/wildchildforlife/lantern:latest
+```
+
+Read-only mounts are deliberate: Lantern only ever reads these directories.
+
+## Reading logs from more than one machine
 
 Lantern lists whatever lives under the Claude directory it reads. To pull in sessions from another
 machine, symlink or mount that machine's project directories into `~/.claude/projects/`:
@@ -162,8 +222,28 @@ pnpm test
 pnpm build
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and house rules, and [AGENTS.md](AGENTS.md) for
-the architecture (Hono + Effect-TS backend, Vite + TanStack Router frontend, SQLite cache).
+To work against the bundled fixtures instead of your own conversations:
+
+```bash
+node dist/main.js --port 4100 --claude-dir ./fixtures/claude-home
+```
+
+[AGENTS.md](AGENTS.md) describes the architecture: a Hono + Effect-TS backend, a Vite + TanStack Router
+frontend, and a SQLite cache.
+
+## Contributing
+
+Bug reports, ideas and pull requests are all welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers the
+setup, the quality gate to run before opening a pull request, and the house rules — no `as` casting,
+Effect-TS for backend side effects, Hono RPC for API calls, and a preference for pure functions.
+
+By taking part you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Support
+
+- **Something broken, or an idea?** Open an [issue](https://github.com/WildChildForLife/lantern/issues).
+- **A vulnerability?** Report it privately — see [Security](#security).
+- **What changed?** See the [releases](https://github.com/WildChildForLife/lantern/releases).
 
 ## Privacy
 


### PR DESCRIPTION
Stacked on #41 (stack #32). The README was already well written — this is a completeness and accuracy pass, not a rewrite, so the existing voice and structure are kept.

## Things that were wrong or missing

**`--terminal-unrestricted` was undocumented.** It drops the restricted shell flags from bash terminal sessions, which widens exactly the hole the security note warns about, and it was in neither the options table nor the security note. Both now cover it, along with its `LANTERN_TERMINAL_UNRESTRICTED` variable.

**`--source` did not say what it accepts.** The valid ids are `claude-code`, `codex` and `opencode`; `LANTERN_SOURCES` takes them comma-separated. Neither was written down.

**Codex and opencode were advertised but unreachable.** The intro promises three CLIs, but nothing said where those two are read from or how to move the paths — they follow the CLIs' own conventions (`CODEX_HOME`, and `XDG_DATA_HOME` for opencode, which has no home of its own). Worse, the Docker instructions mount `~/.claude` alone, so anyone following them literally could enable Codex or opencode in settings and simply see nothing. There is now a table of the three roots and a Docker command with all three mounts.

**The arm64 claim was subtly false.** The README said a Raspberry Pi or Apple Silicon machine "works the same way". It does, except for the in-app terminal: `@replit/ruspty` publishes no `linux/arm64` build, so that feature is unavailable on the arm64 image — the same gap #40 fixed the reporting for. Called out where the platforms are listed.

**`SECURITY.md` and `CODE_OF_CONDUCT.md` were unreachable from the README.** Both files existed; neither was linked. The security section now points at the policy and the private advisory form.

## Added

- A table of contents — the README is long enough to need one.
- A `Support` section: issues, private advisories, releases.
- A `Contributing` section summarising the house rules and linking `CONTRIBUTING.md`.
- The fixtures command (`--claude-dir ./fixtures/claude-home`) under Development, so contributors need not read `CONTRIBUTING.md` to avoid pointing the tool at their own conversations.
- A note that flag-style environment variables accept `1` or `true`.

## Verification

Every documented flag, default and environment variable was checked against the source rather than carried over: the option list against `src/server/main.ts`, and the defaults, variable names and flag parsing against `LanternOptionsService` (`port` `3000`, `hostname` `localhost`, comma-split `LANTERN_SOURCES`, `1`/`true` flags). The source roots come from `ApplicationContext.sourceRoot` and the two adapters. All three screenshots referenced still exist.

`pnpm lint` (oxlint + oxfmt) and `typecheck` pass. Docs-only change — no source touched.

Note on the first push: `oxfmt` formats Markdown, and the options table padding it wants is not what I wrote by hand, so CI's `check` failed on formatting. `pnpm gatecheck check` had passed because it only inspects the diff. Fixed with `pnpm fix:oxfmt`, which re-padded table columns only — no wording changed.

## One thing I could not verify

`CONTRIBUTING.md` says the house rules "come from the upstream project", which suggests Lantern derives from another project. High-grade READMEs credit that, but I could not determine which project it is, so I have not invented an attribution. If there is an upstream to acknowledge, tell me and I will add it.

Carries the same unrelated pre-existing failure as the rest of the stack: the `SyncService` `canonicalPath` snapshot fails on case-insensitive filesystems (macOS only, CI green).
