### PR TITLE
docs: add macOS, Linux and Windows install guides, and fix Windows home resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ searchable list of everything, and a board view of the lot.
 ## Contents
 
 - [What it does](#what-it-does)
-- [Install](#install) · [Docker](#docker) · [npm](#npm) · [From source](#from-source)
+- [Install](#install) · [macOS](#macos) · [Linux](#linux) · [Windows](#windows) · [Docker](#docker) ·
+  [From source](#from-source) · [Platform support](#platform-support)
 - [Usage](#usage) · [Options](#options) · [Security](#security)
 - [Reading other agent CLIs](#reading-other-agent-clis)
 - [Reading logs from more than one machine](#reading-logs-from-more-than-one-machine)
@@ -60,13 +61,80 @@ searchable list of everything, and a board view of the lot.
 
 ## Install
 
+Lantern needs **Node.js 24 or newer** for the npm and source installs; Docker needs neither. Claude
+Code itself must be installed and signed in for the optional AI topic naming — everything else works
+without it.
+
+Pick your platform below, or jump to [Docker](#docker), which is the same on all three.
+
+### macOS
+
+Node 24 via Homebrew, then run it:
+
+```bash
+brew install node          # or: brew install fnm && fnm install 24
+npx lantern-viewer --port 3400
+```
+
+Sessions are read from `~/.claude/projects`. Everything works here, the in-app terminal included, on
+both Intel and Apple Silicon.
+
+### Linux
+
+Node 24 from your distribution or a version manager — most distro repositories still ship something
+older, so check `node --version` before filing a bug:
+
+```bash
+# Debian/Ubuntu, via NodeSource
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash - && sudo apt-get install -y nodejs
+# Fedora
+sudo dnf install nodejs
+# Arch
+sudo pacman -S nodejs npm
+
+npx lantern-viewer --port 3400
+```
+
+Sessions are read from `~/.claude/projects`. On `x86_64` everything works. On `aarch64` the in-app
+terminal is unavailable — see [Platform support](#platform-support).
+
+### Windows
+
+Node 24 via winget, then run it from PowerShell:
+
+```powershell
+winget install OpenJS.NodeJS
+npx lantern-viewer --port 3400
+```
+
+Sessions are read from `%USERPROFILE%\.claude\projects`, and Lantern's own cache from
+`%USERPROFILE%\.lantern`. The `claude` executable is found on `PATH` with `where`, so if
+`where claude` finds nothing, pass `--executable` with the full path.
+
+The in-app terminal is unavailable on Windows — see [Platform support](#platform-support). If you want
+it, run Lantern inside **WSL2** instead and treat it as a Linux install; sessions written by a Windows
+Claude Code are then reachable at `/mnt/c/Users/<you>/.claude`, which you can point at with
+`--claude-dir`.
+
 ### Docker
+
+Identical on macOS, Linux and Windows apart from the volume syntax.
 
 ```bash
 docker run -d --name lantern \
   -p 127.0.0.1:3400:3400 \
   -v "$HOME/.claude:/root/.claude:ro" \
   -v lantern_cache:/root/.lantern \
+  ghcr.io/wildchildforlife/lantern:latest
+```
+
+On Windows PowerShell, swap `$HOME` for `$env:USERPROFILE` and the line continuations for backticks:
+
+```powershell
+docker run -d --name lantern `
+  -p 127.0.0.1:3400:3400 `
+  -v "${env:USERPROFILE}\.claude:/root/.claude:ro" `
+  -v lantern_cache:/root/.lantern `
   ghcr.io/wildchildforlife/lantern:latest
 ```
 
@@ -82,24 +150,11 @@ That mounts Claude Code's logs only. To read Codex or opencode as well, see
 [Reading other agent CLIs](#reading-other-agent-clis).
 
 Images are published for `linux/amd64` and `linux/arm64`, so a Raspberry Pi or an Apple Silicon
-machine works the same way — with one exception: the in-app terminal is unavailable on the `arm64`
-image, because the PTY library it uses publishes no `linux/arm64` build. Everything else is identical,
-and Lantern says so in its startup log rather than failing.
-
-### npm
-
-```bash
-npx lantern-viewer --port 3400
-```
-
-Or install it properly:
-
-```bash
-npm install -g lantern-viewer
-lantern --port 3400
-```
+machine works the same way — except the in-app terminal, which is unavailable on the `arm64` image.
 
 ### From source
+
+Any platform, once Node 24 and pnpm are present:
 
 ```bash
 git clone https://github.com/WildChildForLife/lantern.git
@@ -111,8 +166,21 @@ node dist/main.js --port 3400
 
 Then open <http://localhost:3400>.
 
-> **Requirements:** Node.js 24 or newer for the npm and source installs. Claude Code itself must be
-> installed and signed in for the optional AI topic naming; everything else works without it.
+### Platform support
+
+Everything works everywhere except the in-app terminal, which needs a prebuilt PTY binary that
+`@replit/ruspty` does not publish for every target. Where it is missing, Lantern disables the terminal
+and says so in its startup log; nothing else is affected.
+
+| Platform                       | Supported | In-app terminal |
+| ------------------------------ | --------- | --------------- |
+| macOS (Apple Silicon or Intel) | yes       | yes             |
+| Linux `x86_64`                 | yes       | yes             |
+| Linux `aarch64`                | yes       | no              |
+| Windows                        | yes       | no — use WSL2   |
+
+CI runs on Linux only, so macOS and Windows are verified by hand rather than on every commit. Reports
+from either are welcome.
 
 ## Usage
 
@@ -154,8 +222,8 @@ in [SECURITY.md](SECURITY.md). Please use
 [GitHub Security Advisories](https://github.com/WildChildForLife/lantern/security/advisories/new)
 rather than a public issue.
 
-Lantern keeps its cache, push keys and schedules in `~/.lantern/`. Deleting that directory costs
-nothing but a rebuild on the next start.
+Lantern keeps its cache, push keys and schedules in `~/.lantern/` (`%USERPROFILE%\.lantern` on
+Windows). Deleting that directory costs nothing but a rebuild on the next start.
 
 ## Reading other agent CLIs
 
@@ -167,6 +235,8 @@ at them is the same gesture as pointing the CLI at them:
 | `claude-code` | `~/.claude`               | `--claude-dir` / `LANTERN_CLAUDE_DIR` |
 | `codex`       | `~/.codex`                | `CODEX_HOME`                          |
 | `opencode`    | `~/.local/share/opencode` | `XDG_DATA_HOME`                       |
+
+`~` here is `$HOME`, or `%USERPROFILE%` on Windows shells that do not set `HOME`.
 
 Enable the ones you want in settings, or scope a single run with `--source`.
 

--- a/src/server/core/platform/resolveHomeDirectory.test.ts
+++ b/src/server/core/platform/resolveHomeDirectory.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveHomeDirectory } from "./resolveHomeDirectory.ts";
+
+describe("resolveHomeDirectory", () => {
+  it("uses HOME on platforms that set it", () => {
+    expect(resolveHomeDirectory("/home/ada", undefined)).toBe("/home/ada");
+  });
+
+  it("falls back to USERPROFILE when HOME is unset", () => {
+    // Native Windows: cmd and PowerShell set USERPROFILE only, so reading HOME
+    // alone left the home directory unresolved.
+    expect(resolveHomeDirectory(undefined, "C:\\Users\\Ada")).toBe("C:\\Users\\Ada");
+  });
+
+  it("prefers HOME when both are set", () => {
+    // Git Bash and WSL set both; HOME is the one the user's tooling agrees on.
+    expect(resolveHomeDirectory("/home/ada", "C:\\Users\\Ada")).toBe("/home/ada");
+  });
+
+  it("treats an empty value as unset", () => {
+    expect(resolveHomeDirectory("", "C:\\Users\\Ada")).toBe("C:\\Users\\Ada");
+    expect(resolveHomeDirectory("", "")).toBeUndefined();
+  });
+
+  it("is undefined when neither is set", () => {
+    expect(resolveHomeDirectory(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/src/server/core/platform/resolveHomeDirectory.ts
+++ b/src/server/core/platform/resolveHomeDirectory.ts
@@ -1,0 +1,24 @@
+/**
+ * The user's home directory, taken from whichever variable the platform sets.
+ *
+ * Unix-like systems set `HOME`. Windows sets `USERPROFILE` and leaves `HOME`
+ * unset unless a POSIX layer such as Git Bash or WSL adds it, so reading `HOME`
+ * alone resolved to the filesystem root there and Lantern looked for `.claude`
+ * in `C:\` — finding nothing, while Claude Code wrote to the real profile.
+ *
+ * `HOME` wins when both are set: under Git Bash or WSL it is the one the user's
+ * own tooling agrees on, and overriding it is how someone points Lantern at a
+ * different profile.
+ */
+export const resolveHomeDirectory = (
+  home: string | undefined,
+  userProfile: string | undefined,
+): string | undefined => {
+  if (home !== undefined && home !== "") {
+    return home;
+  }
+  if (userProfile !== undefined && userProfile !== "") {
+    return userProfile;
+  }
+  return undefined;
+};

--- a/src/server/core/platform/schema.ts
+++ b/src/server/core/platform/schema.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 export const envSchema = z.object({
   LANTERN_ENV: z.enum(["development", "production", "test"]).optional().default("development"),
   HOME: z.string().optional(),
+  /** Windows names the home directory here and leaves `HOME` unset. */
+  USERPROFILE: z.string().optional(),
   PATH: z.string().optional(),
   SHELL: z.string().optional(),
   LANTERN_TERMINAL_SHELL: z.string().optional(),

--- a/src/server/core/platform/services/ApplicationContext.ts
+++ b/src/server/core/platform/services/ApplicationContext.ts
@@ -6,6 +6,7 @@ import {
   OPENCODE_SOURCE_ID,
   type SourceId,
 } from "../../source/models/SourceId.ts";
+import { resolveHomeDirectory } from "../resolveHomeDirectory.ts";
 import { EnvService } from "./EnvService.ts";
 import { LanternOptionsService } from "./LanternOptionsService.ts";
 
@@ -22,9 +23,15 @@ const LayerImpl = Effect.gen(function* () {
   const optionsService = yield* LanternOptionsService;
   const envService = yield* EnvService;
 
+  /** `HOME`, or `USERPROFILE` on the Windows shells that set only that. */
+  const resolvedHomeDirectory = Effect.all([
+    envService.getEnv("HOME"),
+    envService.getEnv("USERPROFILE"),
+  ]).pipe(Effect.map(([home, userProfile]) => resolveHomeDirectory(home, userProfile)));
+
   const claudeCodePaths = Effect.gen(function* () {
     const cliClaudeDir = yield* optionsService.getOption("claudeDir");
-    const homeDirectory = yield* envService.getEnv("HOME");
+    const homeDirectory = yield* resolvedHomeDirectory;
     const globalClaudeDirectoryPath =
       cliClaudeDir === undefined
         ? path.resolve(homeDirectory ?? "/", ".claude")
@@ -45,7 +52,7 @@ const LayerImpl = Effect.gen(function* () {
    * Not derivable from `globalClaudeDirectoryPath`: `--claude-dir` can point
    * anywhere, and its parent is then an unrelated directory.
    */
-  const homeDirectory = envService.getEnv("HOME");
+  const homeDirectory = resolvedHomeDirectory;
 
   /**
    * Read here rather than at each call site, so a test can drive the rules of a

--- a/src/server/core/scheduler/config.ts
+++ b/src/server/core/scheduler/config.ts
@@ -1,6 +1,7 @@
 import { FileSystem, Path } from "@effect/platform";
 import { Context, Data, Effect, Layer } from "effect";
 import { stateDirPath } from "../../lib/config/stateDir.ts";
+import { resolveHomeDirectory } from "../platform/resolveHomeDirectory.ts";
 import { EnvService } from "../platform/services/EnvService.ts";
 import { type SchedulerConfig, schedulerConfigSchema } from "./schema.ts";
 
@@ -26,7 +27,10 @@ export class SchedulerConfigBaseDir extends Context.Tag("SchedulerConfigBaseDir"
     Effect.gen(function* () {
       const envService = yield* EnvService;
       const path = yield* Path.Path;
-      const homeDirectory = yield* envService.getEnv("HOME");
+      const homeDirectory = resolveHomeDirectory(
+        yield* envService.getEnv("HOME"),
+        yield* envService.getEnv("USERPROFILE"),
+      );
       return stateDirPath(path, homeDirectory ?? "/");
     }),
   );

--- a/src/server/core/source/config.ts
+++ b/src/server/core/source/config.ts
@@ -1,6 +1,7 @@
 import { FileSystem, Path } from "@effect/platform";
 import { Context, Effect, Layer } from "effect";
 import { stateDirPath } from "../../lib/config/stateDir.ts";
+import { resolveHomeDirectory } from "../platform/resolveHomeDirectory.ts";
 import { EnvService } from "../platform/services/EnvService.ts";
 import { defaultSourceConfig, type SourceConfig, sourceConfigSchema } from "./schema.ts";
 
@@ -17,7 +18,10 @@ export class SourceConfigBaseDir extends Context.Tag("SourceConfigBaseDir")<
     Effect.gen(function* () {
       const envService = yield* EnvService;
       const path = yield* Path.Path;
-      const homeDirectory = yield* envService.getEnv("HOME");
+      const homeDirectory = resolveHomeDirectory(
+        yield* envService.getEnv("HOME"),
+        yield* envService.getEnv("USERPROFILE"),
+      );
       return stateDirPath(path, homeDirectory ?? "/");
     }),
   );

--- a/src/testing/layers/testPlatformLayer.ts
+++ b/src/testing/layers/testPlatformLayer.ts
@@ -59,6 +59,10 @@ export const testPlatformLayer = (overrides?: {
             return overrides?.env?.LANTERN_ENV ?? "development";
           case "HOME":
             return overrides?.env?.HOME ?? process.cwd();
+          // Left unset by default: HOME already answers on the platforms tests
+          // run on, and defaulting both would hide which one a test is exercising.
+          case "USERPROFILE":
+            return overrides?.env?.USERPROFILE ?? undefined;
           case "PATH":
             return overrides?.env?.PATH ?? undefined;
           case "SHELL":


### PR DESCRIPTION
Gives macOS, Linux and Windows their own installation instructions — and fixes the bug that writing the Windows ones uncovered.

## Windows did not work at all

Before documenting a Windows install I checked whether one functions. It did not, silently.

Windows shells set `USERPROFILE` and leave `HOME` unset; only a POSIX layer such as Git Bash or WSL adds `HOME`. Three places read `HOME` directly and fell back to the filesystem root:

- `ApplicationContext.claudeCodePaths` → sessions were looked for in `C:\.claude\projects`, while Claude Code writes to `%USERPROFILE%\.claude\projects`. Lantern started fine and showed nothing.
- `ApplicationContext.homeDirectory` → same for the Codex and opencode roots.
- `SourceConfigBaseDir` and `SchedulerConfigBaseDir` → the state directory resolved to `/.lantern`, which failed outright: `[InitializeService] startScheduler failed: mkdir '/.lantern'`.

Home resolution now prefers `HOME` and falls back to `USERPROFILE`, in one shared pure function. `HOME` still wins when both are set, which is what Git Bash and WSL expect and how someone points Lantern at another profile.

Adding `USERPROFILE` to the env schema also surfaced a non-exhaustive switch in `testPlatformLayer` — the type checker caught it, and it now handles the key explicitly.

### Verified, not assumed

`resolveHomeDirectory` has unit tests for each branch. More usefully, the whole app was run with `HOME` unset and only `USERPROFILE` set, pointing at a fixture profile:

- before: `level=ERROR ... startScheduler failed: mkdir '/.lantern'`, and no sessions found
- after: **zero** `ERROR` lines, `fullSync completed`, `file watcher on .../winhome/.claude/projects`, and `.lantern` created under the fixture profile containing `scheduler/`, `cache.db` and `vapid-keys.json` — the three things the README says live there

## The docs

The install section listed *methods*, so a reader had to work out which applied to them. Each platform now has its own short section: the Node 24 step for that package manager, where its sessions are read from, and its own caveat.

Docker keeps one section, with the PowerShell variant beside the shell one — only the volume syntax (`$env:USERPROFILE`) and the line continuations (backticks) differ.

A support table replaces the scattered platform caveats:

| Platform                       | Supported | In-app terminal |
| ------------------------------ | --------- | --------------- |
| macOS (Apple Silicon or Intel) | yes       | yes             |
| Linux `x86_64`                 | yes       | yes             |
| Linux `aarch64`                | yes       | no              |
| Windows                        | yes       | no — use WSL2   |

That column is taken from `hasRusptyBinary`, not guessed: `@replit/ruspty` publishes darwin x64, darwin arm64 and linux x64 only. Windows users who want a terminal are pointed at WSL2, with the `--claude-dir /mnt/c/Users/<you>/.claude` route for reaching sessions a Windows Claude Code wrote.

The Windows section also notes that the `claude` executable is located with `where` (as the code does), so `--executable` is the fix when it is not on `PATH`.

## Verification

`typecheck`, `lint` (oxlint + oxfmt) and `build` pass; suite is 1150 passing. Every platform claim traces to code: the terminal matrix to `hasRusptyBinary`, `where` to `ClaudeCode.ts` and `resolveOnPath.ts`, the source roots to `ApplicationContext.sourceRoot`, Node 24 to `engines`. All README anchors resolve to real headings.

The README now also states that CI runs on Linux only, so macOS and Windows are hand-verified rather than checked on every commit — worth saying out loud given this PR adds instructions for both.

**One limitation:** the Windows path was exercised by simulating its environment (`HOME` unset, `USERPROFILE` set) on macOS, which covers the resolution bug precisely. It is not the same as running on real Windows, which I cannot do here. The package-manager commands (`winget install OpenJS.NodeJS`, NodeSource, Homebrew) are standard but likewise unexecuted.

Carries the usual unrelated pre-existing failure: the `SyncService` `canonicalPath` snapshot fails on case-insensitive filesystems (macOS only, Linux CI green).
