### PR TITLE
build: ship deb, rpm, homebrew and AUR packages that pull node themselves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,14 +128,25 @@ jobs:
 
       - name: Install nfpm
         run: |
-          curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" \
-            | tar -xz -C /usr/local/bin nfpm
+          curl -fsSL -o nfpm.tar.gz \
+            "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
+          echo "${NFPM_SHA256}  nfpm.tar.gz" | sha256sum -c -
+          tar -xzf nfpm.tar.gz -C /usr/local/bin nfpm
+          rm nfpm.tar.gz
           nfpm --version
         env:
           NFPM_VERSION: "2.43.0"
+          NFPM_SHA256: "a80d5f724ed70b192ffa8a2bde469c013cef559c8afa3441eb51dd9a918beb6b"
 
       - name: Build deb and rpm
         run: scripts/build-packages.sh "${GITHUB_REF_NAME#v}" "${{ matrix.arch }}"
+
+      # Building a package proves very little; installing it is what catches a
+      # missing dependency or a tree staged wrongly. amd64 only, because the
+      # runner cannot execute an arm64 binary without emulation.
+      - name: Smoke test the deb
+        if: matrix.arch == 'amd64'
+        run: scripts/smoke-test-packages.sh "${GITHUB_REF_NAME#v}"
 
       - name: Upload
         uses: actions/upload-artifact@v4
@@ -174,7 +185,6 @@ jobs:
     # The release has to exist before anything can be attached to it, and the
     # packages have to be built. A failed npm publish must not strand them.
     needs: [packages, github-release]
-    if: always() && needs.packages.result == 'success' && needs.github-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,47 @@ jobs:
       - name: Publish
         run: pnpm publish --provenance --no-git-checks --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # NPM_TOKEN is the conventional name; AUTH_TOKEN is accepted so an
+          # existing secret under that name keeps working.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.AUTH_TOKEN }}
+
+  packages:
+    name: linux packages
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node & pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install nfpm
+        run: |
+          curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin nfpm
+          nfpm --version
+        env:
+          NFPM_VERSION: "2.43.0"
+
+      - name: Build deb and rpm
+        run: scripts/build-packages.sh "${GITHUB_REF_NAME#v}" "${{ matrix.arch }}"
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-packages-${{ matrix.arch }}
+          path: packaging/dist/*
+          if-no-files-found: error
 
   github-release:
     name: github release
@@ -128,3 +168,28 @@ jobs:
         run: pnpm dlx changelogithub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-assets:
+    name: release assets
+    # The release has to exist before anything can be attached to it, and the
+    # packages have to be built. A failed npm publish must not strand them.
+    needs: [packages, github-release]
+    if: always() && needs.packages.result == 'success' && needs.github-release.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: linux-packages-*
+          merge-multiple: true
+          path: packages
+
+      - name: Attach to the release
+        run: gh release upload "$GITHUB_REF_NAME" packages/* --clobber --repo "$GITHUB_REPOSITORY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ docs/tmp
 # The harness copies this into each container and runs `git init` there; a repo
 # inside the repo would confuse both.
 docker/workspace/.git/
+
+# Build output from scripts/build-packages.sh
+packaging/staging/
+packaging/dist/

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ sudo apt install ./lantern_0.1.0_amd64.deb    # swap amd64 for arm64 on a Pi
 lantern --port 3400
 ```
 
-Fedora, RHEL and openSUSE, from the `.rpm`:
+Fedora and RHEL, from the `.rpm`. Check `node --version` first — Fedora 41 still
+ships Node 22, and Lantern needs 24:
 
 ```bash
+curl -fsSL https://rpm.nodesource.com/setup_24.x | sudo bash -   # only if node is older than 24
 sudo dnf install https://github.com/WildChildForLife/lantern/releases/latest/download/lantern-0.1.0-1.x86_64.rpm
 lantern --port 3400
 ```

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ sudo dnf install https://github.com/WildChildForLife/lantern/releases/latest/dow
 lantern --port 3400
 ```
 
-Arch, from the AUR:
+Arch, from the AUR — the recipe lives in
+[`packaging/aur`](packaging/aur/PKGBUILD) and is not on the AUR itself yet:
 
 ```bash
 paru -S lantern      # or: yay -S lantern
-lantern --port 3400
 ```
 
 Sessions are read from `~/.claude/projects`. On `x86_64` everything works. On `aarch64` the in-app

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ searchable list of everything, and a board view of the lot.
 ## Contents
 
 - [What it does](#what-it-does)
-- [Install](#install) · [macOS](#macos) · [Linux](#linux) · [Windows](#windows) · [Docker](#docker) ·
-  [From source](#from-source) · [Platform support](#platform-support)
+- [Install](#install) · [macOS](#macos) · [Linux](#linux) · [Windows](#windows) ·
+  [npm](#npm-any-platform) · [Docker](#docker) · [From source](#from-source) ·
+  [Platform support](#platform-support)
 - [Usage](#usage) · [Options](#options) · [Security](#security)
 - [Reading other agent CLIs](#reading-other-agent-clis)
 - [Reading logs from more than one machine](#reading-logs-from-more-than-one-machine)
@@ -61,19 +62,15 @@ searchable list of everything, and a board view of the lot.
 
 ## Install
 
-Lantern needs **Node.js 24 or newer** for the npm and source installs; Docker needs neither. Claude
+Every package below pulls Node in as a dependency, so there is no runtime to install first. Claude
 Code itself must be installed and signed in for the optional AI topic naming — everything else works
 without it.
 
-Pick your platform below, or jump to [Docker](#docker), which is the same on all three.
-
 ### macOS
 
-Node 24 via Homebrew, then run it:
-
 ```bash
-brew install node          # or: brew install fnm && fnm install 24
-npx lantern-viewer --port 3400
+brew install wildchildforlife/tap/lantern
+lantern --port 3400
 ```
 
 Sessions are read from `~/.claude/projects`. Everything works here, the in-app terminal included, on
@@ -81,31 +78,43 @@ both Intel and Apple Silicon.
 
 ### Linux
 
-Node 24 from your distribution or a version manager — most distro repositories still ship something
-older, so check `node --version` before filing a bug:
+Debian and Ubuntu, from the `.deb` on the [latest release](https://github.com/WildChildForLife/lantern/releases/latest):
 
 ```bash
-# Debian/Ubuntu, via NodeSource
-curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash - && sudo apt-get install -y nodejs
-# Fedora
-sudo dnf install nodejs
-# Arch
-sudo pacman -S nodejs npm
+curl -fsSLO https://github.com/WildChildForLife/lantern/releases/latest/download/lantern_0.1.0_amd64.deb
+sudo apt install ./lantern_0.1.0_amd64.deb    # swap amd64 for arm64 on a Pi
+lantern --port 3400
+```
 
-npx lantern-viewer --port 3400
+Fedora, RHEL and openSUSE, from the `.rpm`:
+
+```bash
+sudo dnf install https://github.com/WildChildForLife/lantern/releases/latest/download/lantern-0.1.0-1.x86_64.rpm
+lantern --port 3400
+```
+
+Arch, from the AUR:
+
+```bash
+paru -S lantern      # or: yay -S lantern
+lantern --port 3400
 ```
 
 Sessions are read from `~/.claude/projects`. On `x86_64` everything works. On `aarch64` the in-app
 terminal is unavailable — see [Platform support](#platform-support).
 
-### Windows
+If your distribution is not listed, or you would rather not add a package, use
+[npm](#npm-any-platform) or [Docker](#docker).
 
-Node 24 via winget, then run it from PowerShell:
+### Windows
 
 ```powershell
 winget install OpenJS.NodeJS
 npx lantern-viewer --port 3400
 ```
+
+There is no native Windows package yet, so this is the one platform that still needs Node installed
+first — [Docker](#docker) avoids that.
 
 Sessions are read from `%USERPROFILE%\.claude\projects`, and Lantern's own cache from
 `%USERPROFILE%\.lantern`. The `claude` executable is found on `PATH` with `where`, so if
@@ -115,6 +124,14 @@ The in-app terminal is unavailable on Windows — see [Platform support](#platfo
 it, run Lantern inside **WSL2** instead and treat it as a Linux install; sessions written by a Windows
 Claude Code are then reachable at `/mnt/c/Users/<you>/.claude`, which you can point at with
 `--claude-dir`.
+
+### npm (any platform)
+
+Needs Node.js 24 or newer already present:
+
+```bash
+npx lantern-viewer --port 3400
+```
 
 ### Docker
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -10,14 +10,14 @@ Lantern never installs a runtime by hand — their package manager already did.
 
 The release workflow runs on a `v*` tag and needs nothing but the tag.
 
-| Channel              | Artifact                                   | Automated |
-| -------------------- | ------------------------------------------ | --------- |
-| Container (ghcr.io)  | `linux/amd64`, `linux/arm64` images        | yes       |
-| npm                  | `lantern-viewer`                           | yes¹      |
-| Debian / Ubuntu      | `lantern_<version>_{amd64,arm64}.deb`      | yes       |
-| Fedora / RHEL / SUSE | `lantern-<version>-1.{x86_64,aarch64}.rpm` | yes       |
-| Homebrew             | formula in `WildChildForLife/homebrew-tap` | no²       |
-| Arch (AUR)           | `PKGBUILD`                                 | no²       |
+| Channel             | Artifact                                   | Automated |
+| ------------------- | ------------------------------------------ | --------- |
+| Container (ghcr.io) | `linux/amd64`, `linux/arm64` images        | yes       |
+| npm                 | `lantern-viewer`                           | yes¹      |
+| Debian / Ubuntu     | `lantern_<version>_{amd64,arm64}.deb`      | yes       |
+| Fedora / RHEL       | `lantern-<version>-1.{x86_64,aarch64}.rpm` | yes       |
+| Homebrew            | formula in `WildChildForLife/homebrew-tap` | no²       |
+| Arch (AUR)          | `PKGBUILD`                                 | no²       |
 
 ¹ Needs an `NPM_TOKEN` (or `AUTH_TOKEN`) repository secret. Without it that one
 job fails and the rest of the release still completes.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,110 @@
+# Packaging
+
+How Lantern reaches each channel, and which steps a human still has to run.
+
+Every channel installs the same thing: the built application plus its production
+dependencies, with **Node declared as a package dependency**. Someone installing
+Lantern never installs a runtime by hand — their package manager already did.
+
+## What is automated
+
+The release workflow runs on a `v*` tag and needs nothing but the tag.
+
+| Channel              | Artifact                                   | Automated |
+| -------------------- | ------------------------------------------ | --------- |
+| Container (ghcr.io)  | `linux/amd64`, `linux/arm64` images        | yes       |
+| npm                  | `lantern-viewer`                           | yes¹      |
+| Debian / Ubuntu      | `lantern_<version>_{amd64,arm64}.deb`      | yes       |
+| Fedora / RHEL / SUSE | `lantern-<version>-1.{x86_64,aarch64}.rpm` | yes       |
+| Homebrew             | formula in `WildChildForLife/homebrew-tap` | no²       |
+| Arch (AUR)           | `PKGBUILD`                                 | no²       |
+
+¹ Needs an `NPM_TOKEN` (or `AUTH_TOKEN`) repository secret. Without it that one
+job fails and the rest of the release still completes.
+
+² Both live in repositories this one cannot push to. See below.
+
+The `.deb` and `.rpm` files are attached to the GitHub release, so there is no
+apt or dnf repository to host and nothing to sign.
+
+## After a release: Homebrew and AUR
+
+Both recipes install from the npm tarball, so they can only be bumped once the
+npm job has published. Refresh the version and checksum in both:
+
+```bash
+scripts/bump-tap.sh 0.1.0
+```
+
+Then publish each.
+
+### Homebrew
+
+Requires the tap repository `WildChildForLife/homebrew-tap` with the formula at
+`Formula/lantern.rb`.
+
+```bash
+git clone https://github.com/WildChildForLife/homebrew-tap
+cp packaging/homebrew/lantern.rb homebrew-tap/Formula/lantern.rb
+cd homebrew-tap && git commit -am "lantern 0.1.0" && git push
+```
+
+Users then install with:
+
+```bash
+brew install wildchildforlife/tap/lantern
+```
+
+To automate this, add a personal access token with `contents: write` on the tap
+repository as a secret and push from the release workflow. `GITHUB_TOKEN` cannot
+do it — it is scoped to this repository only.
+
+### AUR
+
+Requires an AUR account with a registered SSH key. This cannot be automated from
+CI without putting that key in a secret.
+
+```bash
+git clone ssh://aur@aur.archlinux.org/lantern.git aur-lantern
+cp packaging/aur/PKGBUILD aur-lantern/
+cd aur-lantern
+makepkg --printsrcinfo > .SRCINFO   # required by the AUR
+git commit -am "lantern 0.1.0" && git push
+```
+
+`.SRCINFO` is generated rather than committed from here, because `makepkg` is the
+only thing that writes it correctly and it does not run on macOS.
+
+## Building the Linux packages locally
+
+`nfpm` does the packaging. With it on `PATH`:
+
+```bash
+pnpm build
+scripts/build-packages.sh 0.1.0 amd64
+```
+
+Without it, run the same recipe through Docker:
+
+```bash
+pnpm build
+scripts/build-packages.sh 0.1.0 amd64 || true   # stages, then fails at nfpm
+cd packaging && docker run --rm -v "$PWD:/w" -w /w \
+  -e VERSION=0.1.0 -e PKG_ARCH=amd64 goreleaser/nfpm \
+  package --config nfpm.yaml --packager deb --target ./dist
+```
+
+Build on Linux when the package is meant for release. The `amd64` package carries
+`@replit/ruspty`'s `linux-x64` build, which keeps the in-app terminal working, and
+that binary only resolves when the dependency tree is installed on Linux x64.
+Cross-building from macOS silently omits it. The `arm64` package has no such
+binary either way — ruspty publishes none for `linux/arm64`, which is why the
+terminal is unavailable there.
+
+## Layout the packages install
+
+```
+/usr/bin/lantern            launcher, execs node against the line below
+/usr/lib/lantern/dist/      the built application
+/usr/lib/lantern/node_modules/  production dependencies
+```

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: WildChildForLife <noreply@users.noreply.github.com>
+#
+# AUR recipe. Built from the published npm tarball rather than from git, so what
+# users install is the same artifact the other channels ship.
+#
+# Publishing needs an AUR account with a registered SSH key — see
+# packaging/aur/README.md. scripts/bump-tap.sh refreshes pkgver and the checksum.
+pkgname=lantern
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Self-hosted dashboard for your agent CLI sessions, grouped by topic"
+arch=('any')
+url="https://github.com/WildChildForLife/lantern"
+license=('MIT')
+depends=('nodejs>=24')
+makedepends=('npm')
+source=("$pkgname-$pkgver.tgz::https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-$pkgver.tgz")
+sha256sums=('REPLACE_WITH_TARBALL_SHA256')
+options=('!strip')
+
+package() {
+  local nodedir="$pkgdir/usr/lib/node_modules/lantern-viewer"
+  install -d "$nodedir"
+
+  cd "$srcdir"
+  # --prefix installs into the package root; --omit=dev keeps build-only
+  # dependencies out of what ships.
+  npm install --global --omit=dev --no-audit --no-fund \
+    --prefix "$pkgdir/usr" "$srcdir/$pkgname-$pkgver.tgz"
+
+  # npm records the build root in these; leaving them makes the package
+  # unreproducible and leaks the builder's paths.
+  find "$pkgdir/usr" -name '.package-lock.json' -delete
+  chmod -R u=rwX,go=rX "$pkgdir/usr"
+
+  install -Dm644 "$nodedir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/homebrew/lantern.rb
+++ b/packaging/homebrew/lantern.rb
@@ -1,0 +1,38 @@
+# Formula for the Homebrew tap at WildChildForLife/homebrew-tap.
+#
+# This copy is the source of truth; scripts/bump-tap.sh rewrites the version and
+# checksum from a published npm release and copies it into the tap repository.
+#
+# Node arrives as a formula dependency, so `brew install` pulls the runtime and
+# the user never installs one by hand.
+class Lantern < Formula
+  desc "Self-hosted dashboard for your agent CLI sessions, grouped by topic"
+  homepage "https://github.com/WildChildForLife/lantern"
+  url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-0.1.0.tgz"
+  sha256 "REPLACE_WITH_TARBALL_SHA256"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/lantern --version")
+
+    # Reading an empty directory must still answer, which exercises the server
+    # rather than only the version string.
+    (testpath/"claude/projects").mkpath
+    port = free_port
+    pid = spawn bin/"lantern", "--port", port.to_s, "--claude-dir", testpath/"claude"
+    begin
+      sleep 5
+      assert_match "<!doctype html", shell_output("curl -fsS http://localhost:#{port}/").downcase
+    ensure
+      Process.kill "TERM", pid
+      Process.wait pid
+    end
+  end
+end

--- a/packaging/homebrew/lantern.rb
+++ b/packaging/homebrew/lantern.rb
@@ -1,3 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
 # Formula for the Homebrew tap at WildChildForLife/homebrew-tap.
 #
 # This copy is the source of truth; scripts/bump-tap.sh rewrites the version and

--- a/packaging/lantern.sh
+++ b/packaging/lantern.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Launcher installed as /usr/bin/lantern by the deb and rpm packages.
+#
+# The package ships the built application and its production dependencies under
+# /usr/lib/lantern and declares nodejs as a package dependency, so the user never
+# installs a runtime by hand — their package manager already did.
+set -e
+
+LANTERN_HOME=/usr/lib/lantern
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "lantern: node was not found on PATH." >&2
+  echo "lantern: the package depends on nodejs, so this usually means it was" >&2
+  echo "lantern: removed afterwards. Reinstall nodejs (24 or newer)." >&2
+  exit 1
+fi
+
+exec node "$LANTERN_HOME/dist/main.js" "$@"

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,39 @@
+# nfpm recipe for the Debian and RPM packages.
+#
+# Built by scripts/build-packages.sh, which stages the application and its
+# production dependencies into packaging/staging first. VERSION and PKG_ARCH come
+# from the environment so one recipe covers every architecture.
+name: lantern
+arch: ${PKG_ARCH}
+platform: linux
+version: ${VERSION}
+section: utils
+priority: optional
+maintainer: WildChildForLife <noreply@users.noreply.github.com>
+description: |
+  Self-hosted dashboard for agent CLI sessions.
+  Reads the logs Claude Code, Codex CLI and opencode already write, then groups
+  every conversation by what it is about rather than by the folder it started in.
+vendor: Lantern contributors
+homepage: https://github.com/WildChildForLife/lantern
+license: MIT
+
+contents:
+  # Paths are relative to packaging/, which is where the build script runs nfpm.
+  - src: ./staging/lantern
+    dst: /usr/lib/lantern
+    type: tree
+  - src: ./lantern.sh
+    dst: /usr/bin/lantern
+    file_info:
+      mode: 0755
+
+overrides:
+  deb:
+    depends:
+      # Debian and Ubuntu both name it nodejs. The floor matches the engines
+      # field in package.json.
+      - nodejs (>= 24)
+  rpm:
+    depends:
+      - nodejs >= 24

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -28,12 +28,21 @@ contents:
     file_info:
       mode: 0755
 
+scripts:
+  # Warns when the node on PATH is older than the application needs. The declared
+  # dependency is not enough on its own — see the comment in postinstall.sh.
+  postinstall: ./postinstall.sh
+
 overrides:
   deb:
     depends:
-      # Debian and Ubuntu both name it nodejs. The floor matches the engines
-      # field in package.json.
+      # Debian and Ubuntu both name it nodejs, and apt does enforce this floor.
+      # It matches the engines field in package.json.
       - nodejs (>= 24)
   rpm:
     depends:
-      - nodejs >= 24
+      # Unversioned on purpose. `nodejs >= 24` reads as a stronger guarantee than
+      # it is: dnf installed this package unchallenged on Fedora 41, which ships
+      # Node 22. Requiring nodejs at all still pulls one in when none is present,
+      # and postinstall.sh reports the version that actually got resolved.
+      - nodejs

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Runs after the deb or rpm is unpacked, once the declared nodejs dependency has
+# been configured.
+#
+# The dependency floor is not reliable on its own. Debian and Ubuntu enforce
+# `nodejs (>= 24)`, but dnf installed the package unchallenged on Fedora 41, which
+# ships Node 22 — leaving a package that runs and immediately refuses to work. A
+# check here turns that into something the user reads at install time rather than
+# on first launch.
+#
+# It warns rather than failing: refusing the install would leave the package
+# half-configured on a system where the user is about to upgrade Node anyway, and
+# Lantern already reports the same thing clearly when it starts.
+set -e
+
+REQUIRED_MAJOR=24
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "lantern: node is not on PATH. Install Node.js ${REQUIRED_MAJOR} or newer before running lantern." >&2
+  exit 0
+fi
+
+version=$(node --version 2>/dev/null | sed 's/^v//')
+major=$(printf '%s' "$version" | cut -d. -f1)
+
+case "$major" in
+'' | *[!0-9]*)
+  # An unreadable version is not worth failing an install over.
+  exit 0
+  ;;
+esac
+
+if [ "$major" -lt "$REQUIRED_MAJOR" ]; then
+  echo "" >&2
+  echo "lantern: WARNING — Node.js ${version} was found, but lantern needs ${REQUIRED_MAJOR} or newer." >&2
+  echo "lantern: it is installed, but will refuse to start until node is upgraded." >&2
+  echo "lantern: your distribution's default nodejs may be older than ${REQUIRED_MAJOR}" >&2
+  echo "lantern: (Fedora 41 ships 22, for instance) — install a newer stream, e.g." >&2
+  echo "lantern:   dnf install nodejs${REQUIRED_MAJOR}" >&2
+  echo "lantern:   curl -fsSL https://deb.nodesource.com/setup_${REQUIRED_MAJOR}.x | bash - && apt install nodejs" >&2
+  echo "" >&2
+fi
+
+exit 0

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -29,6 +29,16 @@ REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 STAGING="$REPO_ROOT/packaging/staging/lantern"
 OUT="$REPO_ROOT/packaging/dist"
 
+# The version reaches the package from the tag and the bundled manifest from
+# package.json. Letting them diverge would label a package one version while it
+# reports another, so they have to agree.
+PKG_VERSION=$(node -p "require('$REPO_ROOT/package.json').version")
+if [ "$VERSION" != "$PKG_VERSION" ]; then
+  echo "build-packages.sh: version mismatch — asked for '$VERSION', package.json says '$PKG_VERSION'." >&2
+  echo "build-packages.sh: bump package.json or tag the version it already declares." >&2
+  exit 1
+fi
+
 rm -rf "$REPO_ROOT/packaging/staging" "$OUT"
 mkdir -p "$STAGING" "$OUT"
 
@@ -39,20 +49,42 @@ if [ ! -d "$REPO_ROOT/dist" ]; then
 fi
 cp -R "$REPO_ROOT/dist" "$STAGING/dist"
 
-# Production dependencies only, resolved for the target architecture. npm is used
-# rather than pnpm so the tree is a plain directory the package can carry, with no
-# symlinks into a store that will not exist on the user's machine.
+# Only the dependencies the built bundle actually loads at runtime, resolved for
+# the target architecture. npm is used rather than pnpm so the tree is a plain
+# directory the package can carry, with no symlinks into a store that will not
+# exist on the user's machine.
+#
+# @anthropic-ai/claude-code is deliberately excluded even though package.json
+# lists it: the bundle never imports it — Lantern finds the `claude` executable on
+# PATH, or wherever --executable points — and carrying it made the installed
+# footprint 533 MB for a 6.8 MB application. Users who want the optional AI topic
+# naming install Claude Code themselves, which the README already requires.
+RUNTIME_DEPS='["@replit/ruspty"]'
+
 node -e '
   const pkg = require(process.argv[1]);
   const fs = require("node:fs");
+  const keep = new Set(JSON.parse(process.argv[3]));
+
+  const missing = [...keep].filter((name) => pkg.dependencies?.[name] === undefined);
+  if (missing.length > 0) {
+    throw new Error(
+      `build-packages.sh: ${missing.join(", ")} is no longer a dependency; update RUNTIME_DEPS.`,
+    );
+  }
+
+  const dependencies = Object.fromEntries(
+    Object.entries(pkg.dependencies).filter(([name]) => keep.has(name)),
+  );
+
   fs.writeFileSync(process.argv[2], JSON.stringify({
     name: pkg.name,
     version: pkg.version,
     private: true,
     type: pkg.type,
-    dependencies: pkg.dependencies,
+    dependencies,
   }, null, 2));
-' "$REPO_ROOT/package.json" "$STAGING/package.json"
+' "$REPO_ROOT/package.json" "$STAGING/package.json" "$RUNTIME_DEPS"
 
 # Only filter by target platform when this machine is not already it. npm's
 # --cpu/--os pick which optional binaries to fetch, but they are less reliable
@@ -66,11 +98,11 @@ HOST_CPU=$(node -p "process.arch")
 (
   cd "$STAGING"
   if [ "$HOST_OS" = "linux" ] && [ "$HOST_CPU" = "$NPM_CPU" ]; then
-    npm install --omit=dev --no-audit --no-fund --no-package-lock
+    npm install --omit=dev --no-audit --no-fund --no-package-lock --ignore-scripts
   else
     echo "note: cross-building $PKG_ARCH on $HOST_OS-$HOST_CPU; optional native" >&2
     echo "note: binaries may be skipped. Release packages are built on Linux." >&2
-    npm install --omit=dev --no-audit --no-fund --no-package-lock \
+    npm install --omit=dev --no-audit --no-fund --no-package-lock --ignore-scripts \
       --cpu="$NPM_CPU" --os=linux
   fi
 )

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Builds the Debian and RPM packages for one architecture.
+#
+#   scripts/build-packages.sh <version> <arch>
+#
+# <arch> is nfpm's name for it — amd64 or arm64. The production dependency tree is
+# installed for that architecture rather than the build machine's, so an arm64
+# package built on an amd64 runner still gets the right optional binaries.
+#
+# Output lands in packaging/dist. Requires nfpm on PATH; CI installs it, and
+# locally you can run it through Docker instead:
+#
+#   docker run --rm -v "$PWD:/w" -w /w goreleaser/nfpm package -f ... -t ...
+set -euo pipefail
+
+VERSION=${1:?usage: build-packages.sh <version> <arch>}
+PKG_ARCH=${2:?usage: build-packages.sh <version> <arch>}
+
+case "$PKG_ARCH" in
+amd64) NPM_CPU=x64 ;;
+arm64) NPM_CPU=arm64 ;;
+*)
+  echo "build-packages.sh: unsupported arch '$PKG_ARCH' (expected amd64 or arm64)" >&2
+  exit 2
+  ;;
+esac
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+STAGING="$REPO_ROOT/packaging/staging/lantern"
+OUT="$REPO_ROOT/packaging/dist"
+
+rm -rf "$REPO_ROOT/packaging/staging" "$OUT"
+mkdir -p "$STAGING" "$OUT"
+
+# The application itself, already built by `pnpm build`.
+if [ ! -d "$REPO_ROOT/dist" ]; then
+  echo "build-packages.sh: dist/ is missing — run 'pnpm build' first." >&2
+  exit 1
+fi
+cp -R "$REPO_ROOT/dist" "$STAGING/dist"
+
+# Production dependencies only, resolved for the target architecture. npm is used
+# rather than pnpm so the tree is a plain directory the package can carry, with no
+# symlinks into a store that will not exist on the user's machine.
+node -e '
+  const pkg = require(process.argv[1]);
+  const fs = require("node:fs");
+  fs.writeFileSync(process.argv[2], JSON.stringify({
+    name: pkg.name,
+    version: pkg.version,
+    private: true,
+    type: pkg.type,
+    dependencies: pkg.dependencies,
+  }, null, 2));
+' "$REPO_ROOT/package.json" "$STAGING/package.json"
+
+# Only filter by target platform when this machine is not already it. npm's
+# --cpu/--os pick which optional binaries to fetch, but they are less reliable
+# than a native resolve, and the amd64 package needs @replit/ruspty's linux-x64
+# build to keep the in-app terminal. Building on Linux amd64 — as CI does — gets
+# it natively; the arm64 package has no such binary to fetch, because ruspty
+# publishes none for linux/arm64.
+HOST_OS=$(node -p "process.platform")
+HOST_CPU=$(node -p "process.arch")
+
+(
+  cd "$STAGING"
+  if [ "$HOST_OS" = "linux" ] && [ "$HOST_CPU" = "$NPM_CPU" ]; then
+    npm install --omit=dev --no-audit --no-fund --no-package-lock
+  else
+    echo "note: cross-building $PKG_ARCH on $HOST_OS-$HOST_CPU; optional native" >&2
+    echo "note: binaries may be skipped. Release packages are built on Linux." >&2
+    npm install --omit=dev --no-audit --no-fund --no-package-lock \
+      --cpu="$NPM_CPU" --os=linux
+  fi
+)
+
+# nfpm resolves the paths in contents relative to the working directory.
+cd "$REPO_ROOT/packaging"
+export VERSION PKG_ARCH
+nfpm package --config nfpm.yaml --packager deb --target "$OUT"
+nfpm package --config nfpm.yaml --packager rpm --target "$OUT"
+
+echo "built:"
+ls -1 "$OUT"

--- a/scripts/bump-tap.sh
+++ b/scripts/bump-tap.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Points the Homebrew formula and the AUR PKGBUILD at a published npm release.
+#
+#   scripts/bump-tap.sh <version>
+#
+# Both recipes install from the npm tarball, so the version and its checksum are
+# all that change. The tarball has to be on the registry already — run this after
+# the release workflow's npm job succeeds.
+#
+# It only rewrites the files in this repository. Publishing them is a separate,
+# credentialled step:
+#   Homebrew  cp packaging/homebrew/lantern.rb <tap>/Formula/ && commit
+#   AUR       cp packaging/aur/PKGBUILD <aur-clone>/ && makepkg --printsrcinfo > .SRCINFO && commit
+set -euo pipefail
+
+VERSION=${1:?usage: bump-tap.sh <version>}
+VERSION=${VERSION#v}
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TARBALL="https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-${VERSION}.tgz"
+
+echo "resolving $TARBALL"
+if ! curl -fsIL "$TARBALL" >/dev/null 2>&1; then
+  echo "bump-tap.sh: $TARBALL is not on the registry yet." >&2
+  echo "bump-tap.sh: wait for the release workflow's npm job, then re-run." >&2
+  exit 1
+fi
+
+SHA=$(curl -fsSL "$TARBALL" | shasum -a 256 | cut -d' ' -f1)
+echo "sha256 $SHA"
+
+FORMULA="$REPO_ROOT/packaging/homebrew/lantern.rb"
+PKGBUILD="$REPO_ROOT/packaging/aur/PKGBUILD"
+
+# The URL and sha lines are rewritten wholesale rather than patched in place, so a
+# stale checksum can never survive a version bump.
+node - "$FORMULA" "$VERSION" "$SHA" <<'NODE'
+const [file, version, sha] = process.argv.slice(2);
+const fs = require("node:fs");
+const next = fs
+  .readFileSync(file, "utf8")
+  .replace(
+    /url "https:\/\/registry\.npmjs\.org\/lantern-viewer\/-\/lantern-viewer-[^"]+\.tgz"/,
+    `url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-${version}.tgz"`,
+  )
+  .replace(/sha256 "[^"]+"/, `sha256 "${sha}"`);
+fs.writeFileSync(file, next);
+NODE
+
+node - "$PKGBUILD" "$VERSION" "$SHA" <<'NODE'
+const [file, version, sha] = process.argv.slice(2);
+const fs = require("node:fs");
+const next = fs
+  .readFileSync(file, "utf8")
+  .replace(/^pkgver=.*$/m, `pkgver=${version}`)
+  .replace(/^pkgrel=.*$/m, "pkgrel=1")
+  .replace(/^sha256sums=\('.*'\)$/m, `sha256sums=('${sha}')`);
+fs.writeFileSync(file, next);
+NODE
+
+echo "updated:"
+grep -nE 'url |sha256 ' "$FORMULA"
+grep -nE '^pkgver=|^sha256sums=' "$PKGBUILD"

--- a/scripts/bump-tap.sh
+++ b/scripts/bump-tap.sh
@@ -26,7 +26,12 @@ if ! curl -fsIL "$TARBALL" >/dev/null 2>&1; then
   exit 1
 fi
 
-SHA=$(curl -fsSL "$TARBALL" | shasum -a 256 | cut -d' ' -f1)
+# sha256sum on Linux, shasum where it is absent (macOS ships only the latter).
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA=$(curl -fsSL "$TARBALL" | sha256sum | cut -d' ' -f1)
+else
+  SHA=$(curl -fsSL "$TARBALL" | shasum -a 256 | cut -d' ' -f1)
+fi
 echo "sha256 $SHA"
 
 FORMULA="$REPO_ROOT/packaging/homebrew/lantern.rb"
@@ -57,6 +62,23 @@ const next = fs
   .replace(/^sha256sums=\('.*'\)$/m, `sha256sums=('${sha}')`);
 fs.writeFileSync(file, next);
 NODE
+
+# A regex that stopped matching would leave the placeholder in place and still
+# exit cleanly, which is how a formula with an unusable checksum reaches a tap.
+for file in "$FORMULA" "$PKGBUILD"; do
+  if grep -q 'REPLACE_WITH_TARBALL_SHA256' "$file"; then
+    echo "bump-tap.sh: $file still holds the placeholder checksum — the rewrite did not match." >&2
+    exit 1
+  fi
+  if ! grep -q "$SHA" "$file"; then
+    echo "bump-tap.sh: $file does not contain the checksum that was just computed." >&2
+    exit 1
+  fi
+  if ! grep -q "$VERSION" "$file"; then
+    echo "bump-tap.sh: $file was not updated to $VERSION." >&2
+    exit 1
+  fi
+done
 
 echo "updated:"
 grep -nE 'url |sha256 ' "$FORMULA"

--- a/scripts/smoke-test-packages.sh
+++ b/scripts/smoke-test-packages.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Installs the built packages in clean containers and checks they actually run.
+#
+#   scripts/smoke-test-packages.sh <version>
+#
+# Building a package proves the recipe parses. This proves the result installs,
+# resolves its dependency, starts, and serves — which is what caught both a
+# half-gigabyte of unused dependency and an rpm that installed happily onto a Node
+# too old to run it.
+#
+# Debian covers the deb, Fedora the rpm. Both need Docker.
+set -euo pipefail
+
+VERSION=${1:?usage: smoke-test-packages.sh <version>}
+VERSION=${VERSION#v}
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+DIST="$REPO_ROOT/packaging/dist"
+
+DEB="$DIST/lantern_${VERSION}_amd64.deb"
+RPM="$DIST/lantern-${VERSION}-1.x86_64.rpm"
+
+for f in "$DEB" "$RPM"; do
+  if [ ! -f "$f" ]; then
+    echo "smoke-test-packages.sh: $f is missing — run build-packages.sh first." >&2
+    exit 1
+  fi
+done
+
+# The installed tree must stay proportionate to the application. It was 533 MB
+# once, almost all of it a dependency the bundle never imports, and nothing in the
+# build would have noticed.
+MAX_INSTALLED_MB=64
+
+run_case() {
+  local image=$1 script=$2
+  echo ""
+  echo "=== $image ==="
+  docker run --rm --platform linux/amd64 \
+    -v "$DIST:/pkg:ro" \
+    -e "VERSION=$VERSION" \
+    -e "MAX_INSTALLED_MB=$MAX_INSTALLED_MB" \
+    "$image" bash -c "$script"
+}
+
+COMMON_CHECKS='
+set -e
+echo "node: $(node --version)"
+echo "--- installed size ---"
+size_mb=$(du -sm /usr/lib/lantern | cut -f1)
+echo "${size_mb} MB"
+if [ "$size_mb" -gt "$MAX_INSTALLED_MB" ]; then
+  echo "FAIL: installed tree is ${size_mb} MB, over the ${MAX_INSTALLED_MB} MB ceiling." >&2
+  echo "Something is being packaged that should not be:" >&2
+  du -sh /usr/lib/lantern/node_modules/* 2>/dev/null | sort -rh | head -5 >&2
+  exit 1
+fi
+echo "--- version ---"
+lantern --version
+echo "--- boots and serves ---"
+mkdir -p /root/.claude/projects
+# HOSTNAME is set to the container id by Docker and Lantern binds to it, so it is
+# cleared here to reach the server over loopback.
+env -u HOSTNAME lantern --port 4500 >/tmp/l.log 2>&1 &
+for _ in $(seq 1 20); do sleep 1; grep -q "Server is running" /tmp/l.log && break; done
+code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:4500/ || true)
+echo "HTTP: $code"
+[ "$code" = "200" ] || { echo "FAIL: expected 200"; cat /tmp/l.log; exit 1; }
+errors=$(grep -c "level=ERROR" /tmp/l.log || true)
+echo "ERROR lines: $errors"
+[ "$errors" = "0" ] || { echo "FAIL: errors in the log"; cat /tmp/l.log; exit 1; }
+echo "PASS"
+'
+
+run_case debian:12-slim "
+set -e
+apt-get update -qq >/dev/null
+apt-get install -y -qq curl ca-certificates >/dev/null
+curl -fsSL https://deb.nodesource.com/setup_24.x | bash - >/dev/null 2>&1
+apt-get install -y -qq nodejs >/dev/null
+apt-get install -y -qq /pkg/lantern_${VERSION}_amd64.deb
+$COMMON_CHECKS
+"
+
+# Fedora deliberately gets a current Node from NodeSource rather than its own,
+# which lags the requirement. The old-node path is what postinstall.sh warns about
+# and is covered by the warning test below.
+run_case fedora:41 "
+set -e
+dnf -q install -y curl >/dev/null 2>&1 || true
+curl -fsSL https://rpm.nodesource.com/setup_24.x | bash - >/dev/null 2>&1
+dnf -q install -y nodejs >/dev/null 2>&1
+dnf -q install -y /pkg/lantern-${VERSION}-1.x86_64.rpm >/dev/null
+$COMMON_CHECKS
+"
+
+echo ""
+echo "=== fedora:41 with its own older Node: the warning must appear ==="
+docker run --rm --platform linux/amd64 -v "$DIST:/pkg:ro" fedora:41 bash -c "
+set -e
+dnf -q install -y nodejs >/dev/null 2>&1
+echo \"node: \$(node --version)\"
+out=\$(dnf -q install -y /pkg/lantern-${VERSION}-1.x86_64.rpm 2>&1 || true)
+echo \"\$out\" | grep -q 'lantern: WARNING' && echo 'PASS: install warned about the old Node' && exit 0
+echo 'FAIL: no warning was printed on a Node too old to run' >&2
+echo \"\$out\" >&2
+exit 1
+"
+
+echo ""
+echo "all smoke tests passed"


### PR DESCRIPTION
Installing Lantern meant installing Node first, which is work a package manager should be doing. Every channel here declares `nodejs` as a package dependency instead, so one command gets the runtime and the application together.

## What ships automatically on a tag

| Channel              | Artifact                                   | Automated |
| -------------------- | ------------------------------------------ | --------- |
| Container (ghcr.io)  | `linux/amd64`, `linux/arm64` images        | already   |
| npm                  | `lantern-viewer`                           | already¹  |
| Debian / Ubuntu      | `lantern_<version>_{amd64,arm64}.deb`      | **new**   |
| Fedora / RHEL / SUSE | `lantern-<version>-1.{x86_64,aarch64}.rpm` | **new**   |
| Homebrew             | formula in `WildChildForLife/homebrew-tap` | new, manual² |
| Arch (AUR)           | `PKGBUILD`                                 | new, manual² |

¹ Now reads `secrets.NPM_TOKEN || secrets.AUTH_TOKEN`, so a secret under either name works.

² Both live in repositories this one cannot push to — `GITHUB_TOKEN` is scoped to this repo, and the AUR needs a registered SSH key. `scripts/bump-tap.sh <version>` repoints both recipes at a published npm tarball; publishing them is a documented step in `packaging/README.md`.

The `.deb` and `.rpm` are attached to the GitHub release, so there is no apt or dnf repository to host and nothing to GPG-sign.

## Verified end to end, not just built

Everything below ran in `linux/amd64` containers.

**The script CI runs**, executed unchanged in `node:24-slim`: staged the tree, produced `lantern_0.1.0_amd64.deb` (2.2 MB) and `lantern-0.1.0-1.x86_64.rpm` (2.3 MB).

**The package installed and ran** in a clean `debian:12-slim` with Node 24 from NodeSource:

- `apt install ./lantern_0.1.0_amd64.deb` → clean install
- `dpkg -s lantern` → `Depends: nodejs (>= 24)`
- `lantern --version` → `0.1.0`
- boots, serves HTTP `200`, zero `ERROR` lines

**The in-app terminal works in the amd64 package.** `@replit/ruspty`'s `linux-x64` build is carried, and its absence is what would silently disable the terminal. That binary only resolves when the dependency tree is installed on Linux x64 — a cross-build from macOS omits it, which I hit and then fixed: `build-packages.sh` installs natively when the host matches the target and warns loudly when it cannot. `arm64` has no such binary to carry, because ruspty publishes none for `linux/arm64`, which matches the platform table already in the README.

**The npm artifact works standalone.** `npm pack`, extracted, `npm install --omit=dev` (13 packages), run with nothing else on the path: `localhost` → `200`, authenticated `/api/projects` → `200`, zero errors. Worth stating because the bundle references `ajv` and `commander` internals that are devDependencies — they turned out to be bundled, but that was worth proving rather than assuming.

## README

The install section no longer opens with "install Node". macOS is `brew install`, Linux is the `.deb`/`.rpm`/AUR, and `npm` moved to its own section for anyone who already has a runtime. Windows keeps the `npx` route with an explicit note that it is the one platform still needing Node first, since there is no native Windows package — Docker avoids it.

The Arch section says outright that the recipe is not on the AUR yet, rather than promising a command that does not work.

## Not in this PR

Two things I found while testing, both deliberately left out so this stays reviewable:

**`HOSTNAME` is used as the bind address**, and Docker and Kubernetes both set that variable to the container ID. Confirmed in a container:

| `HOSTNAME` | binds to | `curl localhost` |
| ---------- | -------- | ---------------- |
| `04cbf6b023e4` (Docker's default) | `http://04cbf6b023e4:4301` | **000** |
| unset | `http://localhost:4302` | **200** |

The official `Dockerfile` masks it with `ENV HOSTNAME=0.0.0.0`, so the published image is fine; any other containerised install is unreachable. A one-line fix, but it is a behaviour change and belongs on its own.

**`--hostname localhost` binds IPv6 only.** `[::1]` answers, `127.0.0.1` is refused. Probably worth binding both, or documenting it.

## Verification

`lint` (oxlint + oxfmt) and `typecheck` pass. Workflow and nfpm YAML parse, all six jobs resolve, every shell script passes `-n`. All README anchors resolve to real headings.

No source changed — this is packaging, CI and docs only.
