### PR TITLE
fix: attach release packages even when the npm publish fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,15 @@ jobs:
     name: release assets
     # The release has to exist before anything can be attached to it, and the
     # packages have to be built. A failed npm publish must not strand them.
+    #
+    # always() is doing real work here and must stay. This job depends on
+    # github-release, which depends on npm, and GitHub skips a job when anything
+    # in its dependency chain failed — not just its direct needs. Without it, a
+    # failed npm publish silently skips this job and the release is published
+    # with no packages attached, which is exactly what happened to v0.1.0. The
+    # explicit result checks then re-impose the gating always() removes.
     needs: [packages, github-release]
+    if: always() && needs.packages.result == 'success' && needs.github-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Restores the `always()` guard on `release-assets`, which I removed in the review of #44 as redundant. It was not redundant, and `v0.1.0` shipped with no packages attached because of it.

## What happened

`release-assets` depends on `github-release`, which depends on `npm`. GitHub skips a job when **anything in its dependency chain** failed — not only its direct `needs`. So when the npm publish failed with a 403, `github-release` still ran (it has its own `always()`) and succeeded, but `release-assets` was skipped, and the release was published with zero assets.

The comment directly above the job already said "A failed npm publish must not strand them". That was the reason the guard existed, and I removed it anyway.

```
verify:                 success
linux packages (amd64): success
linux packages (arm64): success
container:              success
npm:                    failure
github release:         success
release assets:         skipped   ← both packages built, none attached
```

## Fix

`always()` is back, with the explicit `needs.*.result == 'success'` checks that re-impose the gating `always()` removes, plus a comment explaining why it must not be simplified again.

## Already repaired by hand

The four packages CI built have been uploaded to the `v0.1.0` release, so it is no longer incomplete:

```
lantern_0.1.0_amd64.deb        2,532,662
lantern_0.1.0_arm64.deb        2,230,286
lantern-0.1.0-1.x86_64.rpm     2,635,380
lantern-0.1.0-1.aarch64.rpm    2,325,763
```

These are the artifacts from run 31021580649 — the ones that passed the smoke test — rather than a local rebuild.

## Still outstanding, separately

`npm` failed on a token permission, not on anything in this repo:

```
[E403] Two-factor authentication or granular access token with bypass 2fa
       enabled is required to publish packages.
```

That needs a classic Automation token, or a granular token with 2FA bypass enabled. Once the secret is updated the job can be re-run on the existing tag — no new version required. Homebrew and AUR stay blocked until then, since both source the npm tarball.
