### PR TITLE
chore: point the homebrew and AUR recipes at 0.1.0

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -15,7 +15,7 @@ license=('MIT')
 depends=('nodejs>=24')
 makedepends=('npm')
 source=("$pkgname-$pkgver.tgz::https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-$pkgver.tgz")
-sha256sums=('REPLACE_WITH_TARBALL_SHA256')
+sha256sums=('fbd655b0523e3f10690babcffa5bd1651d1d573b108695c08c7006028c04014e')
 options=('!strip')
 
 package() {

--- a/packaging/homebrew/lantern.rb
+++ b/packaging/homebrew/lantern.rb
@@ -12,7 +12,7 @@ class Lantern < Formula
   desc "Self-hosted dashboard for your agent CLI sessions, grouped by topic"
   homepage "https://github.com/WildChildForLife/lantern"
   url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-0.1.0.tgz"
-  sha256 "REPLACE_WITH_TARBALL_SHA256"
+  sha256 "fbd655b0523e3f10690babcffa5bd1651d1d573b108695c08c7006028c04014e"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
`lantern-viewer@0.1.0` is on the registry, so both recipes now carry its real checksum instead of the placeholder. Produced by `scripts/bump-tap.sh 0.1.0`.

```
sha256 fbd655b0523e3f10690babcffa5bd1651d1d573b108695c08c7006028c04014e
```

## Homebrew — published and verified

The formula is live in [`WildChildForLife/homebrew-tap`](https://github.com/WildChildForLife/homebrew-tap) and was tested as a user would meet it, not just linted:

- `brew audit --strict wildchildforlife/tap/lantern` — exit 0, no findings
- `brew style` — clean apart from a `Sorbet/StrictSigil` preference that applies to homebrew-core internals, not taps
- `brew install wildchildforlife/tap/lantern` — installs, links `/opt/homebrew/bin/lantern`, `lantern --version` → `0.1.0`
- `brew test wildchildforlife/tap/lantern` — exit 0; the test block boots the server against an empty claude dir and asserts the page it serves

Node came in as a formula dependency, which was the point of the exercise.

## AUR — recipe ready, publishing still manual

`pkgver` and `sha256sums` are updated. Pushing needs an AUR account with a registered SSH key, which CI cannot hold without storing that key as a secret. The steps are in `packaging/README.md`:

```bash
git clone ssh://aur@aur.archlinux.org/lantern.git aur-lantern
cp packaging/aur/PKGBUILD aur-lantern/
cd aur-lantern && makepkg --printsrcinfo > .SRCINFO
git commit -am "lantern 0.1.0" && git push
```

I could not validate this one — `makepkg` and `namcap` need Arch. It is checked for valid bash syntax and for the presence of every required field, which is as far as this machine goes.

Once it is on the AUR, the README's `paru -S lantern` line should lose its "not on the AUR yet" caveat.
