### PR TITLE
chore: publish to npm over OIDC instead of a stored token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,12 +99,13 @@ jobs:
         with:
           registry-url: https://registry.npmjs.org
 
+      # Authenticates over OIDC against the trusted publisher configured for
+      # lantern-viewer on npm, so no token is stored here. pnpm exchanges the
+      # id-token granted above for a short-lived publish credential; there is
+      # deliberately no NODE_AUTH_TOKEN fallback, because a silent fallback is
+      # how a long-lived token quietly stays in use.
       - name: Publish
         run: pnpm publish --provenance --no-git-checks --access public
-        env:
-          # NPM_TOKEN is the conventional name; AUTH_TOKEN is accepted so an
-          # existing secret under that name keeps working.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.AUTH_TOKEN }}
 
   packages:
     name: linux packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    # Must match the environment name on npm's trusted publisher for
+    # lantern-viewer. npm checks the environment claim in the id-token, so if the
+    # two ever disagree the exchange fails and nothing publishes. Add protection
+    # rules to this environment in the repository settings — an environment with
+    # none only narrows the claim, it does not gate anything.
+    environment: release
+
     permissions:
       contents: read
       # Required for npm provenance.


### PR DESCRIPTION
`lantern-viewer` now has a GitHub Actions trusted publisher configured on npm, and the `AUTH_TOKEN` secret has been deleted — the repository has no secrets left. This removes the matching `NODE_AUTH_TOKEN` line so the workflow reflects that.

```diff
       - name: Publish
         run: pnpm publish --provenance --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.AUTH_TOKEN }}
```

`id-token: write` is already granted on the job, which is what pnpm exchanges for a short-lived publish credential.

No fallback is left on purpose. `secrets.X` resolves to an empty string when the secret is absent, so keeping the line would have written an empty `_authToken` into `.npmrc` and turned an OIDC misconfiguration into a confusing 401 rather than a clear failure. A silent fallback is also how a long-lived token quietly stays in use.

## Worth being explicit about

**OIDC has not published anything yet.** The only npm publish so far — `0.1.0` — went out on the token, which is now deleted. The trusted publisher was configured through the npmjs.com UI, and I could not verify it from here because `npm trust list` requires a one-time password even to read:

```
npm error code EOTP
npm error This operation requires a one-time password.
```

So the first release after this merges is also the first test of the publisher config. If it is wrong, the `npm` job fails — and there is no longer a fallback.

That failure is contained. The `npm` job is independent of the others, `github-release` is gated on the container rather than npm, and since #45 the packages still attach. So a bad publisher config costs a failed job and a re-run, not a broken release. Recovery is either fixing the config and re-running the job, or publishing that version by hand.

What success looks like in the log — the line that currently reads

```
[WARN] Skipped OIDC: ERR_PNPM_AUTH_TOKEN_EXCHANGE: Failed token exchange request (404)
```

should be absent, with the publish proceeding on the exchanged credential.

## One open question

The publisher appears to be configured unscoped rather than against a GitHub environment. That means anyone with write access to this repository can publish to npm, which is the tradeoff npm warns about when establishing trust. Scoping it to a protected environment would narrow that, and needs `environment:` added to this job to match — a separate change, and only worth it if the wider access matters to you.
