### PR TITLE
chore: release 0.1.1, and describe Lantern as cross-agent

### DIFF
--- a/.github/ISSUE_TEMPLATE/schema-parse-error.yml
+++ b/.github/ISSUE_TEMPLATE/schema-parse-error.yml
@@ -17,11 +17,11 @@ body:
     validations:
       required: true
   - type: input
-    id: claude-code-version
+    id: agent-cli-version
     attributes:
-      label: Claude Code version
-      description: "Run `claude --version` to check."
-      placeholder: "e.g., 1.0.20"
+      label: Agent CLI and version
+      description: "Which CLI wrote the session, and its version — `claude --version`, `codex --version` or `opencode --version`."
+      placeholder: "e.g., claude-code 2.1.220"
     validations:
       required: true
   - type: input

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -3,8 +3,9 @@
 Lantern is designed with privacy in mind:
 
 - **Localhost-Only Communication**: The application runs a web client and API server on localhost, communicating exclusively between your browser and the local server
-- **Anthropic API Access**: Claude Code is invoked via the Claude Agent SDK, which handles communication to the Anthropic API. No other external services are contacted
-- **No Tracking or Telemetry**: The application does not collect crash reports, usage statistics, or any other telemetry. Tracking for Claude Code itself follows the settings configured in Claude Code's own configuration
-- **Network Isolation**: The application functions correctly even if network access is restricted to only the Anthropic API and the localhost port. There are no plans to add external network dependencies in the future
+- **Reads Local Logs Only**: Session history is read from the directories the agent CLIs already write to on this machine — Claude Code, Codex CLI and opencode. Lantern sends none of it anywhere
+- **Provider Access Is Delegated**: Lantern contacts no model provider itself. When you start or resume a session, it invokes the CLI you chose and that CLI talks to its own provider — Claude Code to the Anthropic API via the Claude Agent SDK, and likewise for the others. No other external services are contacted
+- **No Tracking or Telemetry**: The application does not collect crash reports, usage statistics, or any other telemetry. Whatever telemetry each agent CLI does follows that CLI's own configuration, not Lantern's
+- **Network Isolation**: The application functions correctly even if network access is restricted to the localhost port and whichever provider endpoints your enabled CLIs need. There are no plans to add external network dependencies in the future
 
-If you have concerns about network access, you can verify that the application only communicates with the Anthropic API and localhost by monitoring network traffic.
+If you have concerns about network access, you can verify that the application only communicates with localhost and the providers your own CLIs use by monitoring network traffic.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ writes to `~/.claude/projects/` — and, optionally, Codex CLI's rollouts in `~/
 opencode's storage in `~/.local/share/opencode/` — then groups every conversation by **what it is
 about**, not by which folder it happened to start in.
 
-If you run a lot of Claude Code sessions across a lot of projects and machines, the folder view stops
-helping: one directory ends up holding thirty unrelated conversations. Lantern gives you topics, a
-searchable list of everything, and a board view of the lot.
+If you run a lot of agent sessions across a lot of projects and machines — and across more than one
+CLI — the folder view stops helping: one directory ends up holding thirty unrelated conversations.
+Lantern gives you topics, a searchable list of everything, and a board view of the lot.
 
 <p align="center">
   <img src="docs/screenshots/topics.jpg" alt="Topics grouped by subject, each with an icon and a conversation count" width="100%">
@@ -291,16 +291,19 @@ up on restart rather than live.
 
 ## How grouping works
 
-**By default, locally.** Lantern takes the title Claude wrote for each conversation, drops the words
-that say nothing (`fix`, `add`, `error`, `the`), and repeatedly carves off the largest group of
-conversations sharing a word. Leftovers fall back to the folder they were started in, then to any topic
-they mention, and anything still homeless lands in _Uncategorized_. It costs nothing and re-runs on
-every request, so new conversations are grouped as they appear.
+**By default, locally.** Lantern takes the title the agent wrote for each conversation, whichever CLI it
+came from, drops the words that say nothing (`fix`, `add`, `error`, `the`), and repeatedly carves off the
+largest group of conversations sharing a word. Leftovers fall back to the folder they were started in,
+then to any topic they mention, and anything still homeless lands in _Uncategorized_. It costs nothing
+and re-runs on every request, so new conversations are grouped as they appear.
 
-**Optionally, with Claude.** Keyword clustering names topics after words, which is sometimes clumsy.
-Press **Sort N new** and Lantern batches the titles through `claude -p` and stores the answer per
-session. It reuses your existing Claude Code login — there is no API key to configure and no separate
-bill — and only classifies conversations it has not seen before. Nothing runs automatically.
+**Optionally, with Claude Code.** Keyword clustering names topics after words, which is sometimes
+clumsy. Press **Sort N new** and Lantern batches the titles through `claude -p` and stores the answer
+per session. It reuses your existing Claude Code login — there is no API key to configure and no
+separate bill — and only classifies conversations it has not seen before. Nothing runs automatically.
+
+This pass is the one Claude Code-specific feature, because `claude` is the CLI Lantern shells out to.
+It names topics for conversations from every source, not only Claude Code's own.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,11 +13,12 @@ first response within a week.
 
 Lantern is a local-first tool, and the threat model follows from that.
 
-- **It reads your Claude Code session logs**, which contain everything you and Claude said, including
-  anything sensitive that ended up in a prompt. Treat a running instance as equivalent to read access
-  to those logs.
-- **It ships an in-app terminal and can start Claude Code sessions.** Anyone who can reach the port can
-  run commands as the user running Lantern.
+- **It reads your agent CLI session logs** — Claude Code, Codex CLI and opencode, whichever you enable
+  — which contain everything you and the agent said, including anything sensitive that ended up in a
+  prompt. Treat a running instance as equivalent to read access to those logs.
+- **It ships an in-app terminal and can start agent sessions.** Anyone who can reach the port can run
+  commands as the user running Lantern. Only Claude Code is driven interactively; the other sources are
+  read-only, which limits what they add to this but not what they expose.
 - **It binds to `localhost` by default.** That default is the security boundary.
 
 If you expose it beyond localhost:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lantern-viewer",
   "version": "0.1.1",
-  "description": "Find the conversation you forgot you started. A self-hosted dashboard for Claude Code sessions, grouped by topic across every project and machine.",
+  "description": "Find the conversation you forgot you started. A self-hosted, cross-agent dashboard for your coding agent sessions, grouped by topic across every project and machine.",
   "homepage": "https://github.com/WildChildForLife/lantern",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lantern-viewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Find the conversation you forgot you started. A self-hosted dashboard for Claude Code sessions, grouped by topic across every project and machine.",
   "homepage": "https://github.com/WildChildForLife/lantern",
   "license": "MIT",

--- a/src/web/app/conversations/page.tsx
+++ b/src/web/app/conversations/page.tsx
@@ -76,7 +76,7 @@ export const ConversationsPage: FC<Props> = ({ topic }) => {
             </h1>
             <p className="text-muted-foreground text-sm">
               {topic === undefined
-                ? "Every Claude Code session across every project, newest first."
+                ? "Every agent session across every project, newest first."
                 : "Conversations in this topic, newest first."}
             </p>
             {topic !== undefined && (


### PR DESCRIPTION
Version bump to `0.1.1` so `v0.1.1` can be tagged — `scripts/build-packages.sh` refuses to build when the tag and `package.json` disagree — plus the wording fix that makes this worth releasing.

## Lantern was still described as Claude Code only

`package.json`'s description read *"A self-hosted dashboard for Claude Code sessions"*. That string is what npm shows, what `lantern --help` prints, and what every package built from it repeats. Three CLIs have been supported since #35 and #36.

Corrected to **cross-agent** wherever the framing implied one CLI:

| Where | Was |
| --- | --- |
| `package.json` description | "dashboard for Claude Code sessions" — reaches `--help`, npm, all packages |
| Conversations list | "Every Claude Code session across every project" — while listing every source |
| `SECURITY.md` | threat model described as reading Claude Code logs |
| `PRIVACY.md` | claimed the only outbound traffic is the Anthropic API |
| `schema-parse-error` issue template | asked only for a Claude Code version, though those parse errors come from any source |
| README intro, grouping section | "a lot of Claude Code sessions", "the title Claude wrote" |

`PRIVACY.md` was the most wrong: Lantern contacts no provider itself. It invokes whichever CLI you chose, and that CLI talks to its own provider — so promising "only the Anthropic API" was both Claude-centric and inaccurate for a Codex or opencode user.

## Deliberately left alone

Genuinely Claude Code-specific references stay: `--claude-dir` and `LANTERN_CLAUDE_*`, `~/.claude` paths, the `claude-code` source id, interactive session support, and the optional topic naming that shells out to `claude -p`. Renaming the flags would be a breaking change and is out of scope.

That naming pass is now stated plainly as the one Claude Code-specific feature — and that it names topics for conversations from **every** source, not just Claude Code's, which the old wording left ambiguous.

## Since v0.1.0

- #45 `fix:` release assets attach even when the npm publish fails
- #46 `chore:` homebrew and AUR recipes point at 0.1.0
- #47 `chore:` npm publishes over OIDC, no stored token

## Release path this exercises

First release publishing over OIDC with no token fallback, scoped to the `release` environment, restricted to `v*` tags, behind a required approval. The `npm` job will sit waiting for that approval and `github-release`/`release-assets` wait behind it.

## Verification

`lint`, `typecheck` pass; 315 tests across the touched areas pass. The changed UI string is a plain literal, not a Lingui message, so no catalog extraction is needed. The issue template still parses.