### PR TITLE
chore: point the homebrew and AUR recipes at 0.1.1

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -6,7 +6,7 @@
 # Publishing needs an AUR account with a registered SSH key — see
 # packaging/aur/README.md. scripts/bump-tap.sh refreshes pkgver and the checksum.
 pkgname=lantern
-pkgver=0.1.0
+pkgver=0.1.1
 pkgrel=1
 pkgdesc="Self-hosted dashboard for your agent CLI sessions, grouped by topic"
 arch=('any')
@@ -15,7 +15,7 @@ license=('MIT')
 depends=('nodejs>=24')
 makedepends=('npm')
 source=("$pkgname-$pkgver.tgz::https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-$pkgver.tgz")
-sha256sums=('fbd655b0523e3f10690babcffa5bd1651d1d573b108695c08c7006028c04014e')
+sha256sums=('3c6663c170b14b23871e2473de6877aefa74881041245da437a4929230af4882')
 options=('!strip')
 
 package() {

--- a/packaging/homebrew/lantern.rb
+++ b/packaging/homebrew/lantern.rb
@@ -11,8 +11,8 @@
 class Lantern < Formula
   desc "Self-hosted dashboard for your agent CLI sessions, grouped by topic"
   homepage "https://github.com/WildChildForLife/lantern"
-  url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-0.1.0.tgz"
-  sha256 "fbd655b0523e3f10690babcffa5bd1651d1d573b108695c08c7006028c04014e"
+  url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-0.1.1.tgz"
+  sha256 "3c6663c170b14b23871e2473de6877aefa74881041245da437a4929230af4882"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
`lantern-viewer@0.1.1` is on the registry, so both recipes carry its checksum instead of 0.1.0's. Produced by `scripts/bump-tap.sh 0.1.1`.

```
sha256 3c6663c170b14b23871e2473de6877aefa74881041245da437a4929230af4882
```

The tap still serves 0.1.0 until the matching formula is pushed to `WildChildForLife/homebrew-tap`; that push is blocked for me and is noted back in the thread. The AUR recipe remains unpublished.