### PR TITLE
fix: bind to an address that can actually be reached

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM base AS runner
 WORKDIR /app
 ENV LANTERN_ENV=production \
     PORT=3400 \
-    HOSTNAME=0.0.0.0 \
+    LANTERN_HOSTNAME=0.0.0.0 \
     PATH="/app/node_modules/.bin:${PATH}"
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ node dist/main.js [options]
 | Option                      | Environment                     | Description                                                 | Default     |
 | --------------------------- | ------------------------------- | ----------------------------------------------------------- | ----------- |
 | `-p, --port <port>`         | `PORT`                          | Port to listen on                                           | `3000`      |
-| `-h, --hostname <hostname>` | `HOSTNAME`                      | Hostname to bind                                            | `localhost` |
+| `-h, --hostname <hostname>` | `LANTERN_HOSTNAME`              | Address to bind                                             | `127.0.0.1` |
 | `-P, --password <password>` | `LANTERN_PASSWORD`              | Require a password. **Set this if you bind to `0.0.0.0`**   | (none)      |
 | `--claude-dir <path>`       | `LANTERN_CLAUDE_DIR`            | Path to the Claude directory to read                        | `~/.claude` |
 | `-e, --executable <path>`   | `LANTERN_CLAUDE_EXECUTABLE`     | Path to the `claude` executable                             | auto        |
@@ -282,6 +282,15 @@ for more than one
 scopes a single run without changing what is stored in settings.
 
 Flag-style environment variables are on for `1` or `true` and off otherwise.
+
+Lantern binds `127.0.0.1` by default. `localhost` is treated the same way, because
+Node resolves it to `::1` first on a dual-stack machine and that leaves `127.0.0.1`
+refused. Pass `::1` for IPv6 loopback, `::` for both, or `0.0.0.0` for every
+interface — and read [Security](#security) before you do the last one.
+
+The bind address is **not** read from `HOSTNAME`. Docker and Kubernetes set that
+to the container id, so honouring it would leave a container serving on an address
+nothing can reach.
 
 ### Security
 

--- a/src/server/core/platform/resolveBindHostname.test.ts
+++ b/src/server/core/platform/resolveBindHostname.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { LOOPBACK_IPV4, resolveBindHostname } from "./resolveBindHostname.ts";
+
+describe("resolveBindHostname", () => {
+  it("defaults to the IPv4 loopback", () => {
+    // Not "localhost": Node resolves that to ::1 first on a dual-stack machine,
+    // which leaves 127.0.0.1 refused.
+    expect(resolveBindHostname(undefined, undefined)).toBe(LOOPBACK_IPV4);
+  });
+
+  it("resolves an explicit localhost the same way", () => {
+    expect(resolveBindHostname("localhost", undefined)).toBe(LOOPBACK_IPV4);
+    expect(resolveBindHostname(undefined, "localhost")).toBe(LOOPBACK_IPV4);
+  });
+
+  it("passes any other address through untouched", () => {
+    expect(resolveBindHostname("0.0.0.0", undefined)).toBe("0.0.0.0");
+    expect(resolveBindHostname("::1", undefined)).toBe("::1");
+    expect(resolveBindHostname("::", undefined)).toBe("::");
+    expect(resolveBindHostname("192.168.1.10", undefined)).toBe("192.168.1.10");
+  });
+
+  it("prefers the flag over the environment", () => {
+    expect(resolveBindHostname("0.0.0.0", "::1")).toBe("0.0.0.0");
+  });
+
+  it("treats an empty value as unset", () => {
+    expect(resolveBindHostname("", "0.0.0.0")).toBe("0.0.0.0");
+    expect(resolveBindHostname("", "")).toBe(LOOPBACK_IPV4);
+  });
+});

--- a/src/server/core/platform/resolveBindHostname.ts
+++ b/src/server/core/platform/resolveBindHostname.ts
@@ -1,0 +1,36 @@
+/**
+ * The address the server should bind to.
+ *
+ * Two things this deliberately does not do.
+ *
+ * It does not read the bare `HOSTNAME` variable. Docker and Kubernetes both set
+ * that to the container's id, and binding to it leaves the server listening on
+ * an address nothing can reach — the container answered on
+ * `http://<container-id>:3400` and every request to localhost was refused. The
+ * variable belongs to the environment, not to this application, so the
+ * application uses its own `LANTERN_HOSTNAME`.
+ *
+ * It also does not pass `localhost` through to `listen`. Node resolves it and
+ * takes the first answer, which on a dual-stack machine is `::1`, so the server
+ * ends up reachable over IPv6 loopback while `127.0.0.1` is refused. Resolving
+ * it here to the IPv4 loopback makes the common case work; anyone who wants the
+ * IPv6 one asks for `::1`, and `::` binds both.
+ */
+export const LOOPBACK_IPV4 = "127.0.0.1";
+
+export const resolveBindHostname = (
+  cliHostname: string | undefined,
+  lanternHostname: string | undefined,
+): string => {
+  const chosen = firstNonEmpty(cliHostname, lanternHostname) ?? "localhost";
+  return chosen === "localhost" ? LOOPBACK_IPV4 : chosen;
+};
+
+const firstNonEmpty = (...values: ReadonlyArray<string | undefined>): string | undefined => {
+  for (const value of values) {
+    if (value !== undefined && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+};

--- a/src/server/core/platform/schema.ts
+++ b/src/server/core/platform/schema.ts
@@ -6,6 +6,12 @@ export const envSchema = z.object({
   /** Windows names the home directory here and leaves `HOME` unset. */
   USERPROFILE: z.string().optional(),
   PATH: z.string().optional(),
+  /**
+   * The address to bind to. Deliberately not the bare `HOSTNAME`: Docker and
+   * Kubernetes set that to the container id, and binding to it makes the server
+   * unreachable.
+   */
+  LANTERN_HOSTNAME: z.string().optional(),
   SHELL: z.string().optional(),
   LANTERN_TERMINAL_SHELL: z.string().optional(),
   LANTERN_TERMINAL_UNRESTRICTED: z.string().optional(),

--- a/src/server/core/platform/services/LanternOptionsService.ts
+++ b/src/server/core/platform/services/LanternOptionsService.ts
@@ -2,6 +2,7 @@ import { Context, Effect, Layer, Ref } from "effect";
 import type { InferEffect } from "../../../lib/effect/types.ts";
 import { type SourceId, sourceIdSchema } from "../../source/models/SourceId.ts";
 import { withLegacyEnvAliases } from "../legacyEnv.ts";
+import { resolveBindHostname } from "../resolveBindHostname.ts";
 
 export type CliOptions = {
   port: string;
@@ -62,7 +63,7 @@ const isFlagEnabled = (value: string | undefined) => {
 const toLanternOptions = (cliOptions?: CliOptions): LanternOptions => {
   return {
     port: Number.parseInt(cliOptions?.port ?? getOptionalEnv("PORT") ?? "3000", 10),
-    hostname: cliOptions?.hostname ?? getOptionalEnv("HOSTNAME") ?? "localhost",
+    hostname: resolveBindHostname(cliOptions?.hostname, getOptionalEnv("LANTERN_HOSTNAME")),
     verbose:
       cliOptions?.verbose ?? (isFlagEnabled(getOptionalEnv("LANTERN_VERBOSE")) ? true : undefined),
     password: cliOptions?.password ?? getOptionalEnv("LANTERN_PASSWORD") ?? undefined,

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -24,6 +24,7 @@ import { GitController } from "./core/git/presentation/GitController.ts";
 import { GitService } from "./core/git/services/GitService.ts";
 import { NotificationController } from "./core/notification/presentation/NotificationController.ts";
 import { NotificationService } from "./core/notification/services/NotificationService.ts";
+import { resolveBindHostname } from "./core/platform/resolveBindHostname.ts";
 import { isDevelopmentEnv } from "./core/platform/runtimeEnv.ts";
 import type { CliOptions } from "./core/platform/services/LanternOptionsService.ts";
 import { ProjectRepository } from "./core/project/infrastructure/ProjectRepository.ts";
@@ -123,9 +124,12 @@ export const startServer = async (options: CliOptions) => {
       // oxlint-disable-next-line node/no-process-env -- configuration boundary
       (options.port ?? process.env.PORT ?? "3000");
 
-  // biome-ignore lint/style/noProcessEnv: allow only here
-  // oxlint-disable-next-line node/no-process-env -- configuration boundary
-  const hostname = options.hostname ?? process.env.HOSTNAME ?? "localhost";
+  const hostname = resolveBindHostname(
+    options.hostname,
+    // biome-ignore lint/style/noProcessEnv: allow only here
+    // oxlint-disable-next-line node/no-process-env -- configuration boundary
+    process.env.LANTERN_HOSTNAME,
+  );
 
   server.listen(parseInt(port, 10), hostname, () => {
     const info = server.address();

--- a/src/testing/layers/testPlatformLayer.ts
+++ b/src/testing/layers/testPlatformLayer.ts
@@ -63,6 +63,8 @@ export const testPlatformLayer = (overrides?: {
           // run on, and defaulting both would hide which one a test is exercising.
           case "USERPROFILE":
             return overrides?.env?.USERPROFILE ?? undefined;
+          case "LANTERN_HOSTNAME":
+            return overrides?.env?.LANTERN_HOSTNAME ?? undefined;
           case "PATH":
             return overrides?.env?.PATH ?? undefined;
           case "SHELL":


### PR DESCRIPTION
Two bugs with the same symptom: the server starts, logs a URL, and refuses every connection.

## `HOSTNAME` was the bind address

Docker and Kubernetes both set `HOSTNAME` to the container id, and `startServer.ts` read it directly:

```js
const hostname = options.hostname ?? process.env.HOSTNAME ?? "localhost";
```

So a container bound to `http://07b9d8a299ce:3400` and nothing could reach it. The official image only escaped this because its `Dockerfile` sets `HOSTNAME=0.0.0.0` itself — any other containerised install was simply unreachable, which is what I hit installing the `.deb` inside a container.

The variable belongs to the environment, not to this application. The address now comes from `LANTERN_HOSTNAME`, and the `Dockerfile` sets that instead. `HOSTNAME` is no longer read at all — honouring it is the bug, so a fallback would only preserve it.

## `localhost` bound IPv6 only

`localhost` was passed straight to `listen`. Node resolves it and takes the first answer, which on a dual-stack machine is `::1` — so the server answered on IPv6 loopback while `127.0.0.1` was refused. `curl http://127.0.0.1:PORT` failed against a server that was, by its own log, running.

`localhost` now resolves to `127.0.0.1` explicitly. `::1` and `::` remain available for anyone who wants IPv6 or both.

## Verified, both ways

**Native**, with the trap set deliberately:

```
$ HOSTNAME=some-container-id node dist/main.js --port 4600
Server is running on http://127.0.0.1:4600
127.0.0.1: 200      # was refused before
localhost: 200
```

**Container**, rebuilt from this branch:

```
Server is running on http://0.0.0.0:3400
HOSTNAME inside container: 07b9d8a299ce      # set, and correctly ignored
curl from host: 200
```

## Shape

The decision is a pure function, `resolveBindHostname`, with unit tests for each branch — matching how `resolveHomeDirectory` and `hasRusptyBinary` are structured. It is used by both `startServer` and `LanternOptionsService`, which had drifted: the service read the env through `EnvService` while the bind site read `process.env` directly, so they could disagree about what the address was.

`LANTERN_HOSTNAME` is added to the env schema, and `testPlatformLayer`'s exhaustive switch handles it — the type checker catches that one.

## Breaking

Anyone setting `HOSTNAME` deliberately to choose the bind address must switch to `LANTERN_HOSTNAME`. The README documents the new variable, the `127.0.0.1` default, and why `HOSTNAME` is ignored.

## Verification

`lint`, `typecheck`, `build` pass. 1329 tests pass; the single failure is the known `SyncService` `canonicalPath` snapshot that fails only on case-insensitive filesystems (macOS), green on Linux CI.
