### PR TITLE
ci: push the homebrew formula from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,63 @@ jobs:
           path: packaging/dist/*
           if-no-files-found: error
 
+  homebrew:
+    name: homebrew tap
+    # The formula installs from the npm tarball, so it can only be bumped once
+    # that tarball exists.
+    needs: npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Mapped here because the secrets context is not available to step `if`
+    # conditions; env is.
+    env:
+      TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node & pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Point the recipes at this release
+        run: scripts/bump-tap.sh "${GITHUB_REF_NAME#v}"
+
+      - name: Push the formula to the tap
+        # GITHUB_TOKEN cannot reach another repository, so this needs a token
+        # scoped to the tap. Without it the step is skipped rather than failing
+        # the release — a stale formula is worth less than a red release, and the
+        # summary below says plainly what happened.
+        if: ${{ env.TAP_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ env.TAP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY_OWNER}/homebrew-tap.git" tap
+          cp packaging/homebrew/lantern.rb tap/Formula/lantern.rb
+          cd tap
+          git config user.name "WildChildForLife"
+          git config user.email "youssef.elgharbaoui@gmail.com"
+          if git diff --quiet; then
+            echo "formula already at ${VERSION#v}, nothing to push"
+            exit 0
+          fi
+          git commit -am "lantern ${VERSION#v}"
+          git push
+          echo "pushed formula ${VERSION#v} to the tap" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Say so when the tap was not updated
+        if: ${{ env.TAP_TOKEN == '' }}
+        run: |
+          {
+            echo "### Homebrew tap not updated"
+            echo ""
+            echo "\`TAP_GITHUB_TOKEN\` is not set, so the formula still points at the previous release."
+            echo "Bump it by hand with \`scripts/bump-tap.sh ${GITHUB_REF_NAME#v}\` — see \`packaging/README.md\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   github-release:
     name: github release
     needs: [container, npm]

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -16,13 +16,16 @@ The release workflow runs on a `v*` tag and needs nothing but the tag.
 | npm                 | `lantern-viewer`                           | yes¹      |
 | Debian / Ubuntu     | `lantern_<version>_{amd64,arm64}.deb`      | yes       |
 | Fedora / RHEL       | `lantern-<version>-1.{x86_64,aarch64}.rpm` | yes       |
-| Homebrew            | formula in `WildChildForLife/homebrew-tap` | no²       |
+| Homebrew            | formula in `WildChildForLife/homebrew-tap` | yes²      |
 | Arch (AUR)          | `PKGBUILD`                                 | no²       |
 
 ¹ Needs an `NPM_TOKEN` (or `AUTH_TOKEN`) repository secret. Without it that one
 job fails and the rest of the release still completes.
 
-² Both live in repositories this one cannot push to. See below.
+² Automated, but only when `TAP_GITHUB_TOKEN` is set — `GITHUB_TOKEN` cannot reach
+another repository. Without it the release still succeeds and the run summary says
+the formula was left behind. The AUR stays manual: publishing there needs an SSH
+key registered to an AUR account, which is not something to keep in a secret.
 
 The `.deb` and `.rpm` files are attached to the GitHub release, so there is no
 apt or dnf repository to host and nothing to sign.
@@ -40,13 +43,32 @@ Then publish each.
 
 ### Homebrew
 
-Requires the tap repository `WildChildForLife/homebrew-tap` with the formula at
-`Formula/lantern.rb`.
+The release workflow does this. The `homebrew` job runs after `npm` — the formula
+installs from the npm tarball, so it can only be bumped once that exists — points
+`packaging/homebrew/lantern.rb` at the new version, and pushes it to
+`WildChildForLife/homebrew-tap` as `Formula/lantern.rb`.
+
+It needs a `TAP_GITHUB_TOKEN` secret, because `GITHUB_TOKEN` is scoped to this
+repository alone. Use a **fine-grained** personal access token:
+
+- Resource owner: `WildChildForLife`
+- Repository access: only `WildChildForLife/homebrew-tap`
+- Permissions: **Contents → Read and write**
+- Expiration: set one, and diarise the renewal
 
 ```bash
+gh secret set TAP_GITHUB_TOKEN --repo WildChildForLife/lantern
+```
+
+Without the secret the job still runs, skips the push, and writes a note to the
+run summary — a stale formula is worth less than a failed release. To do it by
+hand in that case:
+
+```bash
+scripts/bump-tap.sh 0.2.0
 git clone https://github.com/WildChildForLife/homebrew-tap
 cp packaging/homebrew/lantern.rb homebrew-tap/Formula/lantern.rb
-cd homebrew-tap && git commit -am "lantern 0.1.0" && git push
+cd homebrew-tap && git commit -am "lantern 0.2.0" && git push
 ```
 
 Users then install with:

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -6,7 +6,7 @@
 # Publishing needs an AUR account with a registered SSH key — see
 # packaging/aur/README.md. scripts/bump-tap.sh refreshes pkgver and the checksum.
 pkgname=lantern
-pkgver=0.1.1
+pkgver=0.2.0
 pkgrel=1
 pkgdesc="Self-hosted dashboard for your agent CLI sessions, grouped by topic"
 arch=('any')
@@ -15,7 +15,7 @@ license=('MIT')
 depends=('nodejs>=24')
 makedepends=('npm')
 source=("$pkgname-$pkgver.tgz::https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-$pkgver.tgz")
-sha256sums=('3c6663c170b14b23871e2473de6877aefa74881041245da437a4929230af4882')
+sha256sums=('344b29d69a3a22a94c58cab43c825c5e12ca39437b71cec6f2c48baf2a006a12')
 options=('!strip')
 
 package() {

--- a/packaging/homebrew/lantern.rb
+++ b/packaging/homebrew/lantern.rb
@@ -11,8 +11,8 @@
 class Lantern < Formula
   desc "Self-hosted dashboard for your agent CLI sessions, grouped by topic"
   homepage "https://github.com/WildChildForLife/lantern"
-  url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-0.1.1.tgz"
-  sha256 "3c6663c170b14b23871e2473de6877aefa74881041245da437a4929230af4882"
+  url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-0.2.0.tgz"
+  sha256 "344b29d69a3a22a94c58cab43c825c5e12ca39437b71cec6f2c48baf2a006a12"
   license "MIT"
 
   depends_on "node"

--- a/scripts/bump-tap.sh
+++ b/scripts/bump-tap.sh
@@ -20,11 +20,21 @@ REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 TARBALL="https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-${VERSION}.tgz"
 
 echo "resolving $TARBALL"
-if ! curl -fsIL "$TARBALL" >/dev/null 2>&1; then
-  echo "bump-tap.sh: $TARBALL is not on the registry yet." >&2
-  echo "bump-tap.sh: wait for the release workflow's npm job, then re-run." >&2
-  exit 1
-fi
+# The release workflow runs this straight after publishing, so allow for the
+# registry taking a moment to serve what it has just accepted.
+ATTEMPTS=${BUMP_TAP_ATTEMPTS:-10}
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  if curl -fsIL "$TARBALL" >/dev/null 2>&1; then
+    break
+  fi
+  if [ "$attempt" -eq "$ATTEMPTS" ]; then
+    echo "bump-tap.sh: $TARBALL is not on the registry after $ATTEMPTS attempts." >&2
+    echo "bump-tap.sh: check the npm job published, then re-run." >&2
+    exit 1
+  fi
+  echo "  not there yet, retrying in 6s ($attempt/$ATTEMPTS)"
+  sleep 6
+done
 
 # sha256sum on Linux, shasum where it is absent (macOS ships only the latter).
 if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
Every release needed someone to remember to edit a second repository. Until they did, brew served the previous version regardless of what npm had — the formula pins an exact tarball, so npm publishing `0.2.0` is invisible to brew until `Formula/lantern.rb` says so. That has been true for both releases so far; I bumped it by hand each time.

## The job

`homebrew` runs after `npm`, because the formula installs from the tarball that job publishes. It runs `scripts/bump-tap.sh`, then pushes `packaging/homebrew/lantern.rb` to `WildChildForLife/homebrew-tap` as `Formula/lantern.rb`.

`bump-tap.sh` now retries while the registry catches up with what it has just accepted, instead of failing on the first miss — the job runs seconds after the publish.

## The credential, and the tension

`GITHUB_TOKEN` is scoped to this repository, so pushing to the tap needs `TAP_GITHUB_TOKEN`. That is a long-lived credential, immediately after #47 removed one for npm, and there is no OIDC equivalent for pushing git to another repository.

Narrowed as far as it goes — a **fine-grained** PAT:

- Resource owner: `WildChildForLife`
- Repository access: **only** `WildChildForLife/homebrew-tap`
- Permissions: **Contents → Read and write**
- Expiration: set one

```bash
gh secret set TAP_GITHUB_TOKEN --repo WildChildForLife/lantern
```

**Without the secret the release still succeeds.** The push is skipped and the run summary says the formula was left behind, with the command to do it by hand. A stale formula is worth less than a red release.

## One bug caught before it shipped

The gating was first written as `if: ${{ secrets.TAP_GITHUB_TOKEN != '' }}`. The `secrets` context is **not available to step `if` conditions** — it would have read as empty and skipped the push on every release, silently, looking exactly like a missing secret. It is mapped to a job-level `env` and tested through that.

## Verification

Both paths of `bump-tap.sh` exercised:

```
retry:  BUMP_TAP_ATTEMPTS=2 scripts/bump-tap.sh 9.9.9
        → retries, then fails with a clear message
happy:  scripts/bump-tap.sh 0.2.0
        → rewrites url + sha256 in both recipes
```

The workflow parses and all seven jobs resolve; `lint` passes. This also carries the in-repo recipe bump to `0.2.0` — the tap already serves it from my manual push, but the source copy still said `0.1.1`.

**Not verified end to end:** the job itself has never run. Like the rest of the release workflow it is tag-only, so its first real exercise is the next tag. If the secret is absent it takes the skip path, which is the safe one.

## AUR stays manual

Publishing there needs an SSH key registered to an AUR account. That does not belong in a repository secret, and there is no equivalent of a scoped token for it.