### PR TITLE
chore: name the AUR package lantern-viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,11 @@ Arch, from the AUR — the recipe lives in
 [`packaging/aur`](packaging/aur/PKGBUILD) and is not on the AUR itself yet:
 
 ```bash
-paru -S lantern      # or: yay -S lantern
+paru -S lantern-viewer      # or: yay -S lantern-viewer
 ```
+
+Named `lantern-viewer` there because an unrelated censorship-circumvention tool
+already claims `lantern` on the AUR. The command it installs is still `lantern`.
 
 Sessions are read from `~/.claude/projects`. On `x86_64` everything works. On `aarch64` the in-app
 terminal is unavailable — see [Platform support](#platform-support).

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -46,7 +46,7 @@ Requires the tap repository `WildChildForLife/homebrew-tap` with the formula at
 ```bash
 git clone https://github.com/WildChildForLife/homebrew-tap
 cp packaging/homebrew/lantern.rb homebrew-tap/Formula/lantern.rb
-cd homebrew-tap && git commit -am "lantern 0.1.0" && git push
+cd homebrew-tap && git commit -am "lantern 0.2.0" && git push
 ```
 
 Users then install with:
@@ -65,11 +65,11 @@ Requires an AUR account with a registered SSH key. This cannot be automated from
 CI without putting that key in a secret.
 
 ```bash
-git clone ssh://aur@aur.archlinux.org/lantern.git aur-lantern
+git clone ssh://aur@aur.archlinux.org/lantern-viewer.git aur-lantern
 cp packaging/aur/PKGBUILD aur-lantern/
 cd aur-lantern
 makepkg --printsrcinfo > .SRCINFO   # required by the AUR
-git commit -am "lantern 0.1.0" && git push
+git commit -am "lantern-viewer 0.2.0" && git push
 ```
 
 `.SRCINFO` is generated rather than committed from here, because `makepkg` is the

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -3,9 +3,15 @@
 # AUR recipe. Built from the published npm tarball rather than from git, so what
 # users install is the same artifact the other channels ship.
 #
+# Named lantern-viewer, not lantern: the unrelated censorship-circumvention tool
+# already on the AUR declares provides=('lantern') and conflicts=('lantern'), so
+# that name would be refused. Its binary is /usr/bin/Lantern against our
+# /usr/bin/lantern, which do not collide on a case-sensitive filesystem — the two
+# packages can be installed side by side, so no conflicts entry is needed here.
+#
 # Publishing needs an AUR account with a registered SSH key — see
-# packaging/aur/README.md. scripts/bump-tap.sh refreshes pkgver and the checksum.
-pkgname=lantern
+# packaging/README.md. scripts/bump-tap.sh refreshes pkgver and the checksum.
+pkgname=lantern-viewer
 pkgver=0.1.1
 pkgrel=1
 pkgdesc="Self-hosted dashboard for your agent CLI sessions, grouped by topic"


### PR DESCRIPTION
The AUR recipe was `pkgname=lantern`. That name is unusable there.

## Why

An unrelated censorship-circumvention tool already sits on the AUR as `lantern-bin`, and its recipe claims the bare name:

```bash
provides=("lantern")
conflicts=("lantern")
```

So publishing ours as `lantern` would be refused by pacman outright, not merely be confusing. `lantern-viewer` matches the npm package and sidesteps it.

## No conflicts entry

I was going to add `conflicts=('lantern-bin')` on the assumption both install `/usr/bin/lantern`. Reading their PKGBUILD says otherwise:

```bash
ln -sf /opt/Lantern/Lantern "${pkgdir}/usr/bin/Lantern"
```

Theirs is `/usr/bin/Lantern`, ours is `/usr/bin/lantern` — distinct on a case-sensitive filesystem. The two can be installed side by side, so declaring a conflict would wrongly block that.

## Scope

`pkgname` only. The installed command is still `lantern`; `source` already pointed at the `lantern-viewer` npm tarball and `package()` already installed into `node_modules/lantern-viewer`, so both were consistent with the new name. README and `packaging/README.md` updated, including the clone URL.

## Not verified

Same caveat as before: `makepkg` and `namcap` need Arch, which I do not have. This is syntax-checked bash with the required fields present. First real test is the publish, which is blocked anyway — AUR's web frontend is returning 503 behind its proof-of-work gate, though its RPC API answers, so it is a partial outage on their side.