### PR TITLE
docs: rewrite the contributing guide as Lantern's own

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,14 @@ pnpm gatecheck check
 ```
 
 That runs formatting, linting, type checking and tests over your diff, and is the same gate CI applies.
-Please also run `./scripts/lingui-check.sh` if you touched user-facing strings.
+
+Two things it will not catch, so run them yourself when they apply:
+
+- `pnpm lint` — `gatecheck` only inspects the diff, and `oxfmt` formats Markdown as well as code, so a
+  documentation change can pass the gate and still fail CI.
+- `./scripts/lingui-check.sh` — if you touched user-facing strings.
 
 ## House rules
-
-These come from the upstream project and still hold:
 
 - **No `as` type casting**, anywhere, including tests. If the types look unsolvable without it, say so
   in the pull request rather than casting around it.
@@ -37,8 +40,12 @@ These come from the upstream project and still hold:
   rather than `node:fs`, `node:path` or `child_process`.
 - **Hono RPC + TanStack Query for API calls.** No raw `fetch` in the web app.
 - **Prefer pure functions.** Reach for Effect only where you genuinely need side effects or state; pure
-  logic is easier to test and most of the interesting code here is pure.
-- Write tests alongside the change. The clustering logic in particular is pure and easy to cover.
+  logic is easier to test and most of the interesting code here is pure. `resolveHomeDirectory`,
+  `hasRusptyBinary` and `resolveBindHostname` are the shape to copy: a plain function, a file of its
+  own, and a test for each branch.
+- **Write tests alongside the change.** The clustering logic in particular is pure and easy to cover.
+- **Read from the source adapters, never from a hard-coded path.** Lantern reads Claude Code, Codex
+  CLI, opencode, Qwen Code, GitHub Copilot CLI and goose. Anything that assumes one of them is a bug.
 
 ## Commit messages
 
@@ -51,6 +58,17 @@ These come from the upstream project and still hold:
 | `chore`, `ci`, `build`, `refactor` | Internal work, excluded from release notes |
 
 Use `fix` only for things a user would notice. A linter or type error is a `chore`.
+
+Commit messages become the release notes, so write the description for someone reading the changelog
+rather than the diff.
+
+## Releasing
+
+Push a `v*` tag and the workflow does the rest: container images, the npm package, Debian and RPM
+packages attached to the release, the release notes, and the Homebrew formula. The tag has to match
+the `version` in `package.json` or the build refuses to run.
+
+`packaging/README.md` covers the parts that need a human, and which secrets each channel needs.
 
 ## Scope
 


### PR DESCRIPTION
The house rules were prefaced with "These come from the upstream project and still hold" rather than being stated as this project's own. They are now written directly, and the guide reflects what the repository does today.

## Added

- **The two checks `gatecheck` cannot make.** It only inspects the diff, and `oxfmt` formats Markdown as well as code — so a documentation-only change can pass the gate and still fail CI on formatting. That caught me on #42. `pnpm lint` and `./scripts/lingui-check.sh` are now called out explicitly.
- **The pure-function shape**, pointing at `resolveHomeDirectory`, `hasRusptyBinary` and `resolveBindHostname` as the pattern: plain function, own file, a test per branch.
- **Nothing may assume a single agent CLI.** Six sources are read now; hard-coding one is a bug. This is the mistake the README had for a while.
- **A releasing section** — tag, what the workflow does, the version guard, and a pointer to `packaging/README.md` for the parts needing a human.
- A note that commit messages become the release notes, so they should read for the changelog.

No behaviour change; documentation only.