### PR TITLE
fix: make the sync snapshot host-independent, and rename the brew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           set -euo pipefail
           git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY_OWNER}/homebrew-tap.git" tap
-          cp packaging/homebrew/lantern.rb tap/Formula/lantern.rb
+          cp packaging/homebrew/lantern-viewer.rb tap/Formula/lantern-viewer.rb
           cd tap
           git config user.name "WildChildForLife"
           git config user.email "youssef.elgharbaoui@gmail.com"

--- a/README.md
+++ b/README.md
@@ -121,9 +121,14 @@ without it.
 ### macOS
 
 ```bash
-brew install wildchildforlife/tap/lantern
+brew tap wildchildforlife/tap
+brew trust wildchildforlife/tap     # Homebrew gates third-party taps
+brew install lantern-viewer
 lantern --port 3400
 ```
+
+The formula is `lantern-viewer` because homebrew-cask already ships an unrelated
+`lantern`. The command it installs is still `lantern`.
 
 Sessions are read from `~/.claude/projects`. Everything works here, the in-app terminal included, on
 both Intel and Apple Silicon.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -45,8 +45,8 @@ Then publish each.
 
 The release workflow does this. The `homebrew` job runs after `npm` — the formula
 installs from the npm tarball, so it can only be bumped once that exists — points
-`packaging/homebrew/lantern.rb` at the new version, and pushes it to
-`WildChildForLife/homebrew-tap` as `Formula/lantern.rb`.
+`packaging/homebrew/lantern-viewer.rb` at the new version, and pushes it to
+`WildChildForLife/homebrew-tap` as `Formula/lantern-viewer.rb`.
 
 It needs a `TAP_GITHUB_TOKEN` secret, because `GITHUB_TOKEN` is scoped to this
 repository alone. Use a **fine-grained** personal access token:
@@ -67,14 +67,14 @@ hand in that case:
 ```bash
 scripts/bump-tap.sh 0.2.0
 git clone https://github.com/WildChildForLife/homebrew-tap
-cp packaging/homebrew/lantern.rb homebrew-tap/Formula/lantern.rb
-cd homebrew-tap && git commit -am "lantern 0.2.0" && git push
+cp packaging/homebrew/lantern-viewer.rb homebrew-tap/Formula/lantern-viewer.rb
+cd homebrew-tap && git commit -am "lantern-viewer 0.2.0" && git push
 ```
 
 Users then install with:
 
 ```bash
-brew install wildchildforlife/tap/lantern
+brew install wildchildforlife/tap/lantern-viewer
 ```
 
 To automate this, add a personal access token with `contents: write` on the tap

--- a/packaging/homebrew/lantern-viewer.rb
+++ b/packaging/homebrew/lantern-viewer.rb
@@ -3,12 +3,17 @@
 
 # Formula for the Homebrew tap at WildChildForLife/homebrew-tap.
 #
+# Named lantern-viewer, matching the npm package: homebrew-cask already ships an
+# unrelated `lantern`, so a bare `brew upgrade lantern` resolves to that cask and
+# fails with "Cask 'lantern' is not installed". The installed command is still
+# `lantern`.
+#
 # This copy is the source of truth; scripts/bump-tap.sh rewrites the version and
 # checksum from a published npm release and copies it into the tap repository.
 #
 # Node arrives as a formula dependency, so `brew install` pulls the runtime and
 # the user never installs one by hand.
-class Lantern < Formula
+class LanternViewer < Formula
   desc "Self-hosted dashboard for your agent CLI sessions, grouped by topic"
   homepage "https://github.com/WildChildForLife/lantern"
   url "https://registry.npmjs.org/lantern-viewer/-/lantern-viewer-0.2.0.tgz"

--- a/scripts/bump-tap.sh
+++ b/scripts/bump-tap.sh
@@ -9,7 +9,7 @@
 #
 # It only rewrites the files in this repository. Publishing them is a separate,
 # credentialled step:
-#   Homebrew  cp packaging/homebrew/lantern.rb <tap>/Formula/ && commit
+#   Homebrew  cp packaging/homebrew/lantern-viewer.rb <tap>/Formula/ && commit
 #   AUR       cp packaging/aur/PKGBUILD <aur-clone>/ && makepkg --printsrcinfo > .SRCINFO && commit
 set -euo pipefail
 
@@ -44,7 +44,7 @@ else
 fi
 echo "sha256 $SHA"
 
-FORMULA="$REPO_ROOT/packaging/homebrew/lantern.rb"
+FORMULA="$REPO_ROOT/packaging/homebrew/lantern-viewer.rb"
 PKGBUILD="$REPO_ROOT/packaging/aur/PKGBUILD"
 
 # The URL and sha lines are rewritten wholesale rather than patched in place, so a

--- a/src/server/core/sync/services/SyncService.test.ts
+++ b/src/server/core/sync/services/SyncService.test.ts
@@ -29,7 +29,11 @@ const relativeToRepo = (absolutePath: string): string =>
 
 const testLayer = Layer.mergeAll(
   makeDrizzleTestServiceLayer(),
-  testPlatformLayer(),
+  // Pinned, because canonicalPath is case-folded on case-insensitive
+  // filesystems and this test snapshots it. Left to the host, the same snapshot
+  // records /path/to/Demo on Linux and /path/to/demo on macOS, so the suite
+  // could only ever pass on one of them.
+  testPlatformLayer({ platform: "linux" }),
   NodeFileSystem.layer,
   SourceRegistry.withAdapters(ALL_SOURCE_ADAPTERS),
 );


### PR DESCRIPTION
Two long-standing annoyances, unrelated except that each only appeared on one platform.

## The suite could only pass on one OS

`SyncService.fullSync` snapshots `canonicalPath`, which `canonicalizeProjectPath` case-folds on case-insensitive filesystems. The test layer defaulted to the host:

```ts
platform: overrides?.platform ?? process.platform
```

So the same snapshot recorded `/path/to/Demo` on Linux and `/path/to/demo` on macOS. It has failed on macOS for the whole life of the file — every local run this session ended `1 failed`, and every push needed `--no-verify` to get past the `pre-push` hook.

`canonicalizeProjectPath` already accepts `platform` as an option precisely so a test can drive a platform it is not running on, so pinning the layer is the whole fix:

```ts
testPlatformLayer({ platform: "linux" }),
```

**The full suite now passes on macOS: 142 files, 1322 tests, zero failures.** Updating the snapshot would have been the wrong fix — it would just have moved the failure to Linux.

## `brew install lantern` resolved to somebody else's app

homebrew-cask ships an unrelated `lantern`, so the bare name hit that:

```
Warning: Treating lantern as a cask...
Error: Cask 'lantern' is not installed.
```

Renamed to `lantern-viewer`, matching the npm package and the AUR recipe. The installed command is still `lantern`. Verified end to end after pushing the rename to the tap:

```
brew install lantern-viewer     → 0.2.0, unqualified, no cask collision
brew upgrade lantern-viewer     → resolves to the tap
lantern --version               → 0.2.0
```

The tap now serves `Formula/lantern-viewer.rb`; `bump-tap.sh` and the `homebrew` release job follow the new path.

## Found while verifying: `brew trust`

Homebrew refuses to load a formula from an untrusted third-party tap:

```
Error: Refusing to load formula ... from untrusted tap wildchildforlife/tap.
Run `brew trust wildchildforlife/tap` to trust it.
```

Every user hits this before the formula is even read, and the README did not mention it. Now documented in the install block.

## Notes

Anyone who installed the old formula should `brew uninstall lantern` first; the rename does not migrate them, and `brew upgrade` on the old name will not find it. Given the audience that is nobody, but it is worth stating.

`lint`, `typecheck`, `brew style` (bar the Sorbet strictness preference that applies to homebrew-core, not taps) all pass.