### PR TITLE
feat: add lantern upgrade, and say when a new version exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,19 @@ jobs:
       # id-token granted above for a short-lived publish credential; there is
       # deliberately no NODE_AUTH_TOKEN fallback, because a silent fallback is
       # how a long-lived token quietly stays in use.
+      # A prerelease goes to the `next` dist-tag, never to `latest`. `latest` is
+      # what a plain `npm install -g lantern-viewer` resolves to, what the
+      # update notice reads, and what `lantern upgrade` installs — one untagged
+      # beta would move every stable install onto it.
       - name: Publish
-        run: pnpm publish --provenance --no-git-checks --access public
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          case "$version" in
+            *-*) tag=next ;;
+            *)   tag=latest ;;
+          esac
+          echo "Publishing $version to the $tag dist-tag"
+          pnpm publish --provenance --no-git-checks --access public --tag "$tag"
 
   packages:
     name: linux packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,17 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.pnpm-store \
 
 COPY . .
 RUN chmod +x scripts/docker-entrypoint.sh
+# verify-deps-before-run is off because the install above ran with
+# --ignore-scripts, which pnpm reads back as "these dependencies are not
+# finished" and answers by running `pnpm install` again before the script. That
+# second install runs the root `prepare` hook, `lefthook install`, which needs a
+# git repository — and .git is deliberately not in the build context. The result
+# was `fatal: not a git repository` failing the image build outright. Nothing is
+# skipped by turning the check off here: the install it wants to repeat is the
+# one on the line above.
 RUN --mount=type=cache,id=pnpm-store,target=/root/.pnpm-store \
-    pnpm build && pnpm prune --prod --ignore-scripts
+    pnpm --config.verify-deps-before-run=false build \
+    && pnpm prune --prod --ignore-scripts
 
 FROM base AS runner
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -329,6 +329,21 @@ to the file — set `LANTERN_PASSWORD` or pass `--password`.
 Nothing prompts without a terminal attached, so Docker, CI and `npx … | tee` start straight up.
 `--no-init` or `LANTERN_NO_INIT=1` turns the offer off for good.
 
+### When a new version appears
+
+Lantern says so in one line at startup, and nothing more:
+
+```text
+Lantern 0.4.0 is available (you have 0.3.0). Run `lantern upgrade`.
+```
+
+The line comes from a cached answer, so it never delays a launch, and the check behind it asks the
+npm registry at most once a day. It stays quiet with no terminal attached, in CI, in Docker, for a
+`.deb`/`.rpm` install and for a git checkout — anywhere the answer would not be something you could
+act on. `NO_UPDATE_NOTIFIER=1`, `LANTERN_NO_UPDATE_NOTIFIER=1`, or `"updateNotifier": false` in
+`~/.lantern/config.json` turn it off entirely, registry request included. The cache itself lives in
+`~/.lantern/update-check.json`.
+
 ## Options
 
 | Option                      | Environment                     | Description                                                 | Default     |
@@ -345,6 +360,8 @@ Nothing prompts without a terminal attached, so Docker, CI and `npx … | tee` s
 | `-v, --verbose`             | `LANTERN_VERBOSE`               | Verbose debug logging                                       | off         |
 | `--source <id>`             | `LANTERN_SOURCES`               | Agent CLI to read; repeat for more. Scopes one run          | stored      |
 | `--no-init`                 | `LANTERN_NO_INIT`               | Never offer the setup wizard on a first launch              | offered     |
+| (none)                      | `NO_UPDATE_NOTIFIER`            | Never mention that a new version exists                     | mentioned   |
+| (none)                      | `LANTERN_NO_UPDATE_NOTIFIER`    | The same thing, under Lantern's own name                    | mentioned   |
 
 `lantern browse` reads `--claude-dir`, `--executable`, `--source` and `--verbose`; the rest belong to
 the server. The port and bind address are ignored by the board, which listens on nothing.
@@ -355,7 +372,9 @@ options — resolve in this order: the flag, then the environment variable, then
 unset, so it does not shadow the file.
 
 `--password`, `--verbose`, `--source` and `--no-init` have no stored tier: they resolve from the flag
-or the environment variable only. Password is deliberate — the wizard never writes one down.
+or the environment variable only. Password is deliberate — the wizard never writes one down. The two
+update-notifier variables are the other way around: no flag, and the stored form is
+`"updateNotifier": false` in `~/.lantern/config.json`. Any non-empty value turns them on.
 
 Valid `--source` ids are `claude-code`, `codex`, `opencode`, `qwen-code`, `copilot` and `goose`. Repeat
 the flag

--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ when a terminal is the wrong shape for what you are doing. See [The web UI](#the
 
 ## Contents
 
-- [Quick start](#quick-start) · [Commands](#commands)
+- [Quick start](#quick-start)
+- [Install](#install) · [macOS](#macos) · [Linux](#linux) · [Windows](#windows) ·
+  [npm](#npm-any-platform) · [Docker](#docker) · [From source](#from-source) ·
+  [Platform support](#platform-support)
+- [Commands](#commands)
 - [The board in your terminal](#the-board-in-your-terminal) · [Setup](#setup) · [Options](#options)
 - [The web UI](#the-web-ui) · [Security](#security)
 - [Supported agents](#supported-agents) · [Reading other agent CLIs](#reading-other-agent-clis) ·
   [Reading logs from more than one machine](#reading-logs-from-more-than-one-machine)
-- [Install](#install) · [macOS](#macos) · [Linux](#linux) · [Windows](#windows) ·
-  [npm](#npm-any-platform) · [Docker](#docker) · [From source](#from-source) ·
-  [Platform support](#platform-support)
 - [How grouping works](#how-grouping-works)
 - [Development](#development) · [Contributing](#contributing) · [Support](#support)
 - [Privacy](#privacy) · [Licence](#licence)
@@ -63,6 +64,171 @@ npx lantern-viewer browse
 
 On a first run Lantern reads your logs into its own cache, then draws the board. For a permanent
 install — Homebrew, `apt`, `dnf`, the AUR, Docker — see [Install](#install).
+
+## Install
+
+Every package below declares Node 24 as a dependency, so your package manager pulls a runtime in when
+one is missing — except where the distribution's own `nodejs` is too old to satisfy it, which is what
+the Debian and Ubuntu note below is about. Claude Code itself must be installed and signed in for the
+optional AI topic naming — everything else works without it.
+
+### macOS
+
+```bash
+brew tap wildchildforlife/tap
+brew trust wildchildforlife/tap     # Homebrew gates third-party taps
+brew install lantern-viewer
+lantern browse                      # or: lantern --port 3400 for the web UI
+```
+
+The formula is `lantern-viewer` because homebrew-cask already ships an unrelated
+`lantern`. The command it installs is still `lantern`.
+
+Sessions are read from `~/.claude/projects`. Everything works here, the in-app terminal included, on
+both Intel and Apple Silicon.
+
+### Linux
+
+Debian and Ubuntu, from the `.deb` on the [latest release](https://github.com/WildChildForLife/lantern/releases/latest).
+The package declares `nodejs (>= 24)` and apt enforces it, so a distribution whose own `nodejs` is
+older — Ubuntu 22.04 ships 12, Debian 12 ships 18 — must get Node 24 first or the install stops at
+`Depends: nodejs (>= 24) but 12.22.9~dfsg-1ubuntu3.6 is to be installed`. This is also the WSL2 case,
+since WSL images track those same releases:
+
+```bash
+node --version                                                      # skip the next two lines if this is v24 or newer
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+sudo apt install -y nodejs
+
+version=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+  https://github.com/WildChildForLife/lantern/releases/latest | sed 's#.*/v##')
+curl -fsSLO "https://github.com/WildChildForLife/lantern/releases/download/v${version}/lantern_${version}_amd64.deb"
+sudo apt install "./lantern_${version}_amd64.deb"                   # swap amd64 for arm64 on a Pi
+lantern browse
+```
+
+Fedora and RHEL, from the `.rpm`. Check `node --version` first — Fedora 41 still
+ships Node 22, and Lantern needs 24. `dnf` does **not** enforce that floor, so an
+old Node here installs cleanly and fails at first launch instead:
+
+```bash
+curl -fsSL https://rpm.nodesource.com/setup_24.x | sudo bash -      # only if node is older than 24
+
+version=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+  https://github.com/WildChildForLife/lantern/releases/latest | sed 's#.*/v##')
+sudo dnf install "https://github.com/WildChildForLife/lantern/releases/download/v${version}/lantern-${version}-1.x86_64.rpm"
+lantern browse
+```
+
+Both snippets read the current version off the `releases/latest` redirect, so they stay right after
+every release. To pin a version instead, replace `${version}` with the one you want.
+
+Arch, from the AUR — the recipe lives in
+[`packaging/aur`](packaging/aur/PKGBUILD) and is not on the AUR itself yet:
+
+```bash
+paru -S lantern      # or: yay -S lantern
+```
+
+Sessions are read from `~/.claude/projects`. On `x86_64` everything works. On `aarch64` the web UI's
+in-app terminal is unavailable — see [Platform support](#platform-support).
+
+If your distribution is not listed, or you would rather not add a package, use
+[npm](#npm-any-platform) or [Docker](#docker).
+
+### Windows
+
+```powershell
+winget install OpenJS.NodeJS
+npx lantern-viewer browse
+```
+
+There is no native Windows package yet, so this is the one platform that still needs Node installed
+first — [Docker](#docker) avoids that, for the web UI.
+
+Sessions are read from `%USERPROFILE%\.claude\projects`, and Lantern's own cache from
+`%USERPROFILE%\.lantern`. The `claude` executable is found on `PATH` with `where`, so if
+`where claude` finds nothing, pass `--executable` with the full path.
+
+The web UI's in-app terminal is unavailable on Windows — see
+[Platform support](#platform-support). If you want it, run Lantern inside **WSL2** instead and treat
+it as a Linux install; sessions written by a Windows Claude Code are then reachable at
+`/mnt/c/Users/<you>/.claude`, which you can point at with `--claude-dir`.
+
+### npm (any platform)
+
+Needs Node.js 24 or newer already present:
+
+```bash
+npx lantern-viewer browse           # the board
+npx lantern-viewer --port 3400      # the web UI
+```
+
+### Docker
+
+For the web UI. `lantern browse` wants a terminal, which is not what a detached container has.
+Identical on macOS, Linux and Windows apart from the volume syntax.
+
+```bash
+docker run -d --name lantern \
+  -p 127.0.0.1:3400:3400 \
+  -v "$HOME/.claude:/root/.claude:ro" \
+  -v lantern_cache:/root/.lantern \
+  ghcr.io/wildchildforlife/lantern:latest
+```
+
+On Windows PowerShell, swap `$HOME` for `$env:USERPROFILE` and the line continuations for backticks:
+
+```powershell
+docker run -d --name lantern `
+  -p 127.0.0.1:3400:3400 `
+  -v "${env:USERPROFILE}\.claude:/root/.claude:ro" `
+  -v lantern_cache:/root/.lantern `
+  ghcr.io/wildchildforlife/lantern:latest
+```
+
+Or with Compose, which is the same thing plus a password:
+
+```bash
+curl -O https://raw.githubusercontent.com/WildChildForLife/lantern/main/docker-compose.yml
+echo "LANTERN_PASSWORD=pick-something" > .env
+docker compose up -d
+```
+
+That mounts Claude Code's logs only. To read Codex or opencode as well, see
+[Reading other agent CLIs](#reading-other-agent-clis).
+
+Images are published for `linux/amd64` and `linux/arm64`, so a Raspberry Pi or an Apple Silicon
+machine works the same way — except the in-app terminal, which is unavailable on the `arm64` image.
+
+### From source
+
+Any platform, once Node 24 and pnpm are present:
+
+```bash
+git clone https://github.com/WildChildForLife/lantern.git
+cd lantern
+pnpm install
+pnpm build
+node dist/main.js browse             # or: node dist/main.js --port 3400
+```
+
+### Platform support
+
+Everything works everywhere except the web UI's in-app terminal, which needs a prebuilt PTY binary
+that `@replit/ruspty` does not publish for every target. Where it is missing, Lantern disables the
+terminal and says so in its startup log; nothing else is affected, and `lantern browse` does not use
+it.
+
+| Platform                       | Supported | In-app terminal |
+| ------------------------------ | --------- | --------------- |
+| macOS (Apple Silicon or Intel) | yes       | yes             |
+| Linux `x86_64`                 | yes       | yes             |
+| Linux `aarch64`                | yes       | no              |
+| Windows                        | yes       | no — use WSL2   |
+
+CI runs on Linux only, so macOS and Windows are verified by hand rather than on every commit. Reports
+from either are welcome.
 
 ## Commands
 
@@ -363,153 +529,6 @@ up on restart rather than live.
 <p align="center">
   <img src="docs/screenshots/conversations.jpg" alt="Every conversation across every project, newest first" width="100%">
 </p>
-
-## Install
-
-Every package below pulls Node in as a dependency, so there is no runtime to install first. Claude
-Code itself must be installed and signed in for the optional AI topic naming — everything else works
-without it.
-
-### macOS
-
-```bash
-brew tap wildchildforlife/tap
-brew trust wildchildforlife/tap     # Homebrew gates third-party taps
-brew install lantern-viewer
-lantern browse                      # or: lantern --port 3400 for the web UI
-```
-
-The formula is `lantern-viewer` because homebrew-cask already ships an unrelated
-`lantern`. The command it installs is still `lantern`.
-
-Sessions are read from `~/.claude/projects`. Everything works here, the in-app terminal included, on
-both Intel and Apple Silicon.
-
-### Linux
-
-Debian and Ubuntu, from the `.deb` on the [latest release](https://github.com/WildChildForLife/lantern/releases/latest):
-
-```bash
-curl -fsSLO https://github.com/WildChildForLife/lantern/releases/latest/download/lantern_0.1.0_amd64.deb
-sudo apt install ./lantern_0.1.0_amd64.deb    # swap amd64 for arm64 on a Pi
-lantern browse
-```
-
-Fedora and RHEL, from the `.rpm`. Check `node --version` first — Fedora 41 still
-ships Node 22, and Lantern needs 24:
-
-```bash
-curl -fsSL https://rpm.nodesource.com/setup_24.x | sudo bash -   # only if node is older than 24
-sudo dnf install https://github.com/WildChildForLife/lantern/releases/latest/download/lantern-0.1.0-1.x86_64.rpm
-lantern browse
-```
-
-Arch, from the AUR — the recipe lives in
-[`packaging/aur`](packaging/aur/PKGBUILD) and is not on the AUR itself yet:
-
-```bash
-paru -S lantern      # or: yay -S lantern
-```
-
-Sessions are read from `~/.claude/projects`. On `x86_64` everything works. On `aarch64` the web UI's
-in-app terminal is unavailable — see [Platform support](#platform-support).
-
-If your distribution is not listed, or you would rather not add a package, use
-[npm](#npm-any-platform) or [Docker](#docker).
-
-### Windows
-
-```powershell
-winget install OpenJS.NodeJS
-npx lantern-viewer browse
-```
-
-There is no native Windows package yet, so this is the one platform that still needs Node installed
-first — [Docker](#docker) avoids that, for the web UI.
-
-Sessions are read from `%USERPROFILE%\.claude\projects`, and Lantern's own cache from
-`%USERPROFILE%\.lantern`. The `claude` executable is found on `PATH` with `where`, so if
-`where claude` finds nothing, pass `--executable` with the full path.
-
-The web UI's in-app terminal is unavailable on Windows — see
-[Platform support](#platform-support). If you want it, run Lantern inside **WSL2** instead and treat
-it as a Linux install; sessions written by a Windows Claude Code are then reachable at
-`/mnt/c/Users/<you>/.claude`, which you can point at with `--claude-dir`.
-
-### npm (any platform)
-
-Needs Node.js 24 or newer already present:
-
-```bash
-npx lantern-viewer browse           # the board
-npx lantern-viewer --port 3400      # the web UI
-```
-
-### Docker
-
-For the web UI. `lantern browse` wants a terminal, which is not what a detached container has.
-Identical on macOS, Linux and Windows apart from the volume syntax.
-
-```bash
-docker run -d --name lantern \
-  -p 127.0.0.1:3400:3400 \
-  -v "$HOME/.claude:/root/.claude:ro" \
-  -v lantern_cache:/root/.lantern \
-  ghcr.io/wildchildforlife/lantern:latest
-```
-
-On Windows PowerShell, swap `$HOME` for `$env:USERPROFILE` and the line continuations for backticks:
-
-```powershell
-docker run -d --name lantern `
-  -p 127.0.0.1:3400:3400 `
-  -v "${env:USERPROFILE}\.claude:/root/.claude:ro" `
-  -v lantern_cache:/root/.lantern `
-  ghcr.io/wildchildforlife/lantern:latest
-```
-
-Or with Compose, which is the same thing plus a password:
-
-```bash
-curl -O https://raw.githubusercontent.com/WildChildForLife/lantern/main/docker-compose.yml
-echo "LANTERN_PASSWORD=pick-something" > .env
-docker compose up -d
-```
-
-That mounts Claude Code's logs only. To read Codex or opencode as well, see
-[Reading other agent CLIs](#reading-other-agent-clis).
-
-Images are published for `linux/amd64` and `linux/arm64`, so a Raspberry Pi or an Apple Silicon
-machine works the same way — except the in-app terminal, which is unavailable on the `arm64` image.
-
-### From source
-
-Any platform, once Node 24 and pnpm are present:
-
-```bash
-git clone https://github.com/WildChildForLife/lantern.git
-cd lantern
-pnpm install
-pnpm build
-node dist/main.js browse             # or: node dist/main.js --port 3400
-```
-
-### Platform support
-
-Everything works everywhere except the web UI's in-app terminal, which needs a prebuilt PTY binary
-that `@replit/ruspty` does not publish for every target. Where it is missing, Lantern disables the
-terminal and says so in its startup log; nothing else is affected, and `lantern browse` does not use
-it.
-
-| Platform                       | Supported | In-app terminal |
-| ------------------------------ | --------- | --------------- |
-| macOS (Apple Silicon or Intel) | yes       | yes             |
-| Linux `x86_64`                 | yes       | yes             |
-| Linux `aarch64`                | yes       | no              |
-| Windows                        | yes       | no — use WSL2   |
-
-CI runs on Linux only, so macOS and Windows are verified by hand rather than on every commit. Reports
-from either are welcome.
 
 ## How grouping works
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ from either are welcome.
 ```bash
 lantern browse             # the board, in your terminal
 lantern init               # set Lantern up, and remember the answers
+lantern upgrade            # move to the latest release
 lantern [options]          # start the web UI
 ```
 
@@ -242,6 +243,12 @@ lantern [options]          # start the web UI
 `--verbose` from the [options](#options) table. `init` takes `--claude-dir`. Either works on both
 sides of the command name — `lantern browse --claude-dir …` and `lantern --claude-dir … browse` mean
 the same thing.
+
+`upgrade` works out how Lantern was installed and runs your package manager's own install command —
+`npm`, `pnpm`, `yarn` or `bun`, whichever put it there. Anything it did not install itself it leaves
+alone and prints the command that would upgrade it: Homebrew, Docker, a git checkout, a `.deb` or
+`.rpm`, or a global prefix this user cannot write to. `--check` reports what is available and
+`--dry-run` shows the command without running it; neither changes anything.
 
 ## The board in your terminal
 

--- a/docker/Dockerfile.lantern
+++ b/docker/Dockerfile.lantern
@@ -25,11 +25,17 @@ RUN npm install -g \
   && npm cache clean --force
 
 # goose ships a binary rather than an npm package.
-ARG GOOSE_VERSION=stable
+#
+# Pinned to a tag like every other CLI here, and to the version
+# compatibility.md records as verified. `stable` used to work as both the
+# release tag and the installer's own version input; the installer now rejects
+# anything that is not semver, so a build that asked for `stable` failed with
+# "invalid version 'stable'" after downloading the script that said so.
+ARG GOOSE_VERSION=v1.45.0
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl bzip2 ca-certificates \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSL "https://github.com/block/goose/releases/download/${GOOSE_VERSION}/download_cli.sh" \
-     | CONFIGURE=false bash \
+     | GOOSE_VERSION="${GOOSE_VERSION}" CONFIGURE=false bash \
   && mv /root/.local/bin/goose /usr/local/bin/goose \
   && chmod 0755 /usr/local/bin/goose

--- a/src/cli/config/cliConfig.ts
+++ b/src/cli/config/cliConfig.ts
@@ -53,6 +53,14 @@ export const cliConfigSchema = z.object({
   terminalShell: z.string().optional(),
   terminalUnrestricted: z.boolean().optional(),
   apiOnly: z.boolean().optional(),
+  /**
+   * Whether to say when a newer Lantern has been published. Unset means yes.
+   *
+   * The one setting here nobody is asked for during setup: it is written by
+   * hand, by somebody who would rather Lantern never spoke to the registry.
+   * `NO_UPDATE_NOTIFIER` and `LANTERN_NO_UPDATE_NOTIFIER` do the same per run.
+   */
+  updateNotifier: z.boolean().optional(),
   browse: browseConfigSchema.prefault({}),
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,4 +44,18 @@ export const registerCliCommands = (program: Command): void => {
       );
       process.exitCode = exitCode;
     });
+
+  program
+    .command("upgrade")
+    .description("upgrade Lantern where it was installed, or say what would")
+    .option("--check", "report what is available, without changing anything")
+    .option("--dry-run", "print the command that would run, without running it")
+    .action(async (_options: unknown, command: Command) => {
+      const { parseUpgradeOptions, runUpgrade } = await import("./upgrade/upgradeCommand.ts");
+
+      // `opts()`, not `optsWithGlobals()`: these two flags belong to this
+      // command alone, so unlike the shared options there is nothing on the
+      // root command to merge in.
+      process.exitCode = await runUpgrade(parseUpgradeOptions(command.opts()));
+    });
 };

--- a/src/cli/update/latestVersion.test.ts
+++ b/src/cli/update/latestVersion.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseLatestVersionResponse } from "./latestVersion.ts";
+
+describe("parseLatestVersionResponse", () => {
+  it("reads the version off the abbreviated packument", () => {
+    expect(parseLatestVersionResponse({ name: "lantern-viewer", version: "0.4.0" })).toBe("0.4.0");
+  });
+
+  /**
+   * A registry error page, an HTML captive portal, a proxy's JSON: none of them
+   * are an answer, and treating one as a version would offer an upgrade to
+   * something that does not exist.
+   */
+  it("treats anything else as no answer at all", () => {
+    expect(parseLatestVersionResponse({ error: "Not found" })).toBeNull();
+    expect(parseLatestVersionResponse({ version: 4 })).toBeNull();
+    expect(parseLatestVersionResponse("0.4.0")).toBeNull();
+    expect(parseLatestVersionResponse(null)).toBeNull();
+  });
+});

--- a/src/cli/update/latestVersion.ts
+++ b/src/cli/update/latestVersion.ts
@@ -1,0 +1,55 @@
+import { HttpClient } from "@effect/platform";
+import { NodeHttpClient } from "@effect/platform-node";
+import { Effect } from "effect";
+import { z } from "zod";
+import packageJson from "../../../package.json" with { type: "json" };
+
+const REGISTRY_URL = `https://registry.npmjs.org/${packageJson.name}/latest`;
+
+/**
+ * Plain JSON, and only the `latest` tag.
+ *
+ * The whole packument lists every version ever published and grows with the
+ * project; this endpoint is the one release manifest. It is also the reason the
+ * `Accept` header is unremarkable — asking this URL for npm's abbreviated
+ * packument type comes back 406, and an empty body reads as "no answer".
+ */
+const ACCEPT = "application/json";
+
+const responseSchema = z.object({ version: z.string() });
+
+/** Kept apart from the request so the shape can be tested without a network. */
+export const parseLatestVersionResponse = (raw: unknown): string | null => {
+  const parsed = responseSchema.safeParse(raw);
+
+  return parsed.success ? parsed.data.version : null;
+};
+
+/**
+ * Asks npm what the newest published version is, or gives up quietly.
+ *
+ * Every failure is the same answer — null. A registry that is down, a machine
+ * with no route out, a proxy that swallows the request: none of them are
+ * problems the user asked Lantern to report, and a CLI that complains about the
+ * network on startup is worse than one that says nothing.
+ *
+ * Note that undici only honours HTTPS_PROXY when it is handed a ProxyAgent, so
+ * behind a corporate proxy this times out and stays silent, by design.
+ */
+export const fetchLatestVersion = (): Promise<string | null> =>
+  Effect.runPromise(
+    HttpClient.get(REGISTRY_URL, { headers: { accept: ACCEPT } }).pipe(
+      Effect.flatMap((response) =>
+        // A registry error, a captive portal, a proxy's own page: anything but
+        // a 2xx is not an answer, and its body is not worth reading.
+        response.status >= 200 && response.status < 300
+          ? response.json
+          : Effect.succeed<unknown>(null),
+      ),
+      Effect.map(parseLatestVersionResponse),
+      Effect.timeout("5 seconds"),
+      Effect.catchAll(() => Effect.succeed(null)),
+      Effect.provide(NodeHttpClient.layerUndici),
+      Effect.scoped,
+    ),
+  );

--- a/src/cli/update/notifyUpdate.ts
+++ b/src/cli/update/notifyUpdate.ts
@@ -1,0 +1,117 @@
+import { NodeContext } from "@effect/platform-node";
+import { Effect } from "effect";
+import packageJson from "../../../package.json" with { type: "json" };
+import { EnvService } from "../../server/core/platform/services/EnvService.ts";
+import { CliConfigBaseDir, readCliConfig } from "../config/cliConfigStore.ts";
+import { detectInstallSource } from "../upgrade/detectInstall.ts";
+import { fetchLatestVersion } from "./latestVersion.ts";
+import { readUpdateCache, type UpdateCache, writeUpdateCache } from "./updateCache.ts";
+import {
+  isNotifiable,
+  isUpdateNotifierSilenced,
+  shouldCheckForUpdate,
+  UPDATE_CHECK_INTERVAL_MS,
+  updateNotice,
+  wantsUpdateCheck,
+} from "./updateCheck.ts";
+
+const runQuietly = <A>(
+  effect: Effect.Effect<A, unknown, CliConfigBaseDir | EnvService | NodeContext.NodeContext>,
+  fallback: A,
+): Promise<A> =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.catchAll(() => Effect.succeed(fallback)),
+      Effect.provide(CliConfigBaseDir.Live),
+      Effect.provide(EnvService.Live),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
+
+/**
+ * Asks the registry and remembers the answer for the next launch.
+ *
+ * Nothing is printed from here. The notice always comes from the cache, so a
+ * slow or unreachable registry can never hold up a command or write over a
+ * screen the board has already taken.
+ */
+const refreshCache = (now: number): Promise<void> =>
+  runQuietly(
+    Effect.gen(function* () {
+      const latest = yield* Effect.promise(() => fetchLatestVersion());
+      if (latest === null) {
+        return;
+      }
+
+      yield* writeUpdateCache({ checkedAt: now, latest });
+    }),
+    undefined,
+  );
+
+/**
+ * Prints the one line saying a newer Lantern exists, when there is one.
+ *
+ * Awaited by `main` before the command runs, and deliberately cheap enough to
+ * be: two small file reads and no network. The request that refreshes the cache
+ * is left running in the background with nothing to say, so `lantern browse`
+ * draws its board at the same moment it always did.
+ *
+ * Every failure is silence. An out-of-date Lantern still works, and a version
+ * check is not worth a word of anybody's error output.
+ */
+export const maybeNotifyUpdate = async (
+  argv: readonly string[],
+  isInteractive: boolean,
+  env: Record<string, string | undefined>,
+  now: number,
+): Promise<void> => {
+  if (!wantsUpdateCheck(argv)) {
+    return;
+  }
+
+  const source = await detectInstallSource().catch(() => null);
+  if (source === null) {
+    return;
+  }
+
+  // Settled before the settings file is opened at all: a container, a .deb, a
+  // checkout and an npx run can do nothing with a notice, and the image starts
+  // on every `docker run` — reading two files to decide to say nothing is two
+  // files too many.
+  if (!isInteractive || !isNotifiable(source.kind)) {
+    return;
+  }
+
+  const [config, cache] = await Promise.all([
+    runQuietly(readCliConfig, null),
+    runQuietly<UpdateCache | null>(readUpdateCache, null),
+  ]);
+
+  const notifier = {
+    isInteractive,
+    env,
+    configOptOut: config?.updateNotifier === false,
+    installSource: source.kind,
+  };
+
+  if (isUpdateNotifierSilenced(notifier)) {
+    return;
+  }
+
+  const notice = updateNotice(packageJson.version, cache?.latest ?? null, source.kind);
+  if (notice !== null) {
+    // stderr, so a notice never lands in output somebody is piping.
+    process.stderr.write(`${notice}\n`);
+  }
+
+  if (
+    shouldCheckForUpdate({
+      ...notifier,
+      lastCheckedAt: cache?.checkedAt ?? null,
+      now,
+      intervalMs: UPDATE_CHECK_INTERVAL_MS,
+    })
+  ) {
+    void refreshCache(now);
+  }
+};

--- a/src/cli/update/updateCache.test.ts
+++ b/src/cli/update/updateCache.test.ts
@@ -1,0 +1,66 @@
+import { FileSystem, Path } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { describe, expect } from "vitest";
+import { CliConfigBaseDir } from "../config/cliConfigStore.ts";
+import { parseUpdateCache, readUpdateCache, writeUpdateCache } from "./updateCache.ts";
+
+const withTempBaseDir = <A, E>(
+  use: (baseDir: string) => Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>,
+) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const baseDir = yield* fs.makeTempDirectoryScoped();
+    return yield* use(baseDir);
+  }).pipe(Effect.scoped, Effect.provide(NodeContext.layer));
+
+const withBaseDir = (baseDir: string) => Layer.succeed(CliConfigBaseDir, baseDir);
+
+describe("parseUpdateCache", () => {
+  it("reads what the last check wrote", () => {
+    expect(parseUpdateCache({ checkedAt: 1, latest: "0.4.0" })).toEqual({
+      checkedAt: 1,
+      latest: "0.4.0",
+    });
+  });
+
+  it("treats anything else as never having checked", () => {
+    expect(parseUpdateCache({ checkedAt: "yesterday", latest: "0.4.0" })).toBeNull();
+    expect(parseUpdateCache(null)).toBeNull();
+  });
+});
+
+describe("updateCache", () => {
+  it.live("reports nothing before the first check", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        expect(yield* readUpdateCache).toBeNull();
+      }).pipe(Effect.provide(withBaseDir(baseDir))),
+    ),
+  );
+
+  it.live("remembers what the registry said", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        yield* writeUpdateCache({ checkedAt: 1_760_000_000_000, latest: "0.4.0" });
+
+        expect(yield* readUpdateCache).toEqual({ checkedAt: 1_760_000_000_000, latest: "0.4.0" });
+      }).pipe(Effect.provide(withBaseDir(baseDir))),
+    ),
+  );
+
+  /** A file somebody edited costs a check, not a launch. */
+  it.live("shrugs off a cache it cannot read", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* fs.writeFileString(path.join(baseDir, "update-check.json"), "{ not json");
+
+        expect(yield* readUpdateCache).toBeNull();
+      }).pipe(Effect.provide(withBaseDir(baseDir))),
+    ),
+  );
+});

--- a/src/cli/update/updateCache.ts
+++ b/src/cli/update/updateCache.ts
@@ -1,0 +1,60 @@
+import { FileSystem, Path } from "@effect/platform";
+import { Effect } from "effect";
+import { z } from "zod";
+import { CliConfigBaseDir } from "../config/cliConfigStore.ts";
+
+const CACHE_FILE = "update-check.json";
+
+/**
+ * What the last registry check found, and when.
+ *
+ * Kept out of `config.json` on purpose: that file answers what the user was
+ * asked, and the settings the board writes are read-modify-written. A timestamp
+ * updating itself in the background has no business racing that.
+ */
+const updateCacheSchema = z.object({
+  checkedAt: z.number(),
+  latest: z.string(),
+});
+
+export type UpdateCache = z.infer<typeof updateCacheSchema>;
+
+export const parseUpdateCache = (raw: unknown): UpdateCache | null => {
+  const result = updateCacheSchema.safeParse(raw);
+
+  return result.success ? result.data : null;
+};
+
+const cachePath = Effect.gen(function* () {
+  const path = yield* Path.Path;
+
+  return path.join(yield* CliConfigBaseDir, CACHE_FILE);
+});
+
+/** Null for anything unreadable: a stale notice is not worth an error. */
+export const readUpdateCache = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const file = yield* cachePath;
+
+  const content = yield* fs.readFileString(file).pipe(Effect.catchAll(() => Effect.succeed("")));
+  if (content === "") {
+    return null;
+  }
+
+  const raw = yield* Effect.try({
+    try: (): unknown => JSON.parse(content),
+    catch: () => null,
+  }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+  return parseUpdateCache(raw);
+});
+
+export const writeUpdateCache = (cache: UpdateCache) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const file = yield* cachePath;
+
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    yield* fs.writeFileString(file, `${JSON.stringify(cache, null, 2)}\n`);
+  });

--- a/src/cli/update/updateCheck.test.ts
+++ b/src/cli/update/updateCheck.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  isUpdateNotifierSilenced,
+  shouldCheckForUpdate,
+  UPDATE_CHECK_INTERVAL_MS,
+  updateNotice,
+  type UpdateCheckContext,
+  wantsUpdateCheck,
+} from "./updateCheck.ts";
+
+const NOW = 1_760_000_000_000;
+
+const base: UpdateCheckContext = {
+  isInteractive: true,
+  env: {},
+  configOptOut: false,
+  installSource: "npm-global",
+  lastCheckedAt: null,
+  now: NOW,
+  intervalMs: UPDATE_CHECK_INTERVAL_MS,
+};
+
+describe("shouldCheckForUpdate", () => {
+  it("asks on a first launch at a terminal", () => {
+    expect(shouldCheckForUpdate(base)).toBe(true);
+  });
+
+  it("asks again once a day has passed, and not before", () => {
+    expect(
+      shouldCheckForUpdate({ ...base, lastCheckedAt: NOW - UPDATE_CHECK_INTERVAL_MS + 1 }),
+    ).toBe(false);
+    expect(shouldCheckForUpdate({ ...base, lastCheckedAt: NOW - UPDATE_CHECK_INTERVAL_MS })).toBe(
+      true,
+    );
+  });
+
+  /** A restored backup or a clock put back must not wedge the check forever. */
+  it("asks again when the last check is in the future", () => {
+    expect(shouldCheckForUpdate({ ...base, lastCheckedAt: NOW + 60_000 })).toBe(true);
+  });
+
+  it("never asks without a terminal", () => {
+    expect(shouldCheckForUpdate({ ...base, isInteractive: false })).toBe(false);
+  });
+
+  it("obeys the settings file", () => {
+    expect(shouldCheckForUpdate({ ...base, configOptOut: true })).toBe(false);
+  });
+
+  it("obeys CI and both opt-out variables", () => {
+    for (const key of ["CI", "NO_UPDATE_NOTIFIER", "LANTERN_NO_UPDATE_NOTIFIER"]) {
+      expect(shouldCheckForUpdate({ ...base, env: { [key]: "1" } })).toBe(false);
+    }
+  });
+
+  /** `NO_UPDATE_NOTIFIER=` is how a shell unsets it, not how it says yes. */
+  it("treats an empty variable as unset", () => {
+    expect(shouldCheckForUpdate({ ...base, env: { NO_UPDATE_NOTIFIER: "" } })).toBe(true);
+  });
+
+  /**
+   * Nobody who cannot act on the answer should be paying for the request, and
+   * a container asking npm about a package it did not install is pure noise.
+   */
+  it("only asks for installs that could take the upgrade", () => {
+    const asked = ["npm-global", "homebrew", "unknown"] as const;
+    const quiet = ["docker", "system-package", "npx-cache", "git-checkout"] as const;
+
+    for (const installSource of asked) {
+      expect(shouldCheckForUpdate({ ...base, installSource })).toBe(true);
+    }
+    for (const installSource of quiet) {
+      expect(shouldCheckForUpdate({ ...base, installSource })).toBe(false);
+    }
+  });
+});
+
+describe("isUpdateNotifierSilenced", () => {
+  const notifier = {
+    isInteractive: base.isInteractive,
+    env: base.env,
+    configOptOut: base.configOptOut,
+    installSource: base.installSource,
+  };
+
+  it("says nothing where it would not be read", () => {
+    expect(isUpdateNotifierSilenced({ ...notifier, isInteractive: false })).toBe(true);
+    expect(isUpdateNotifierSilenced({ ...notifier, installSource: "docker" })).toBe(true);
+  });
+
+  /**
+   * The notice and the request behind it have to agree. Silencing one and not
+   * the other would print yesterday's answer to somebody who asked Lantern to
+   * stop talking about versions.
+   */
+  it("silences the notice with the same switches that stop the request", () => {
+    for (const key of ["CI", "NO_UPDATE_NOTIFIER", "LANTERN_NO_UPDATE_NOTIFIER"]) {
+      expect(isUpdateNotifierSilenced({ ...notifier, env: { [key]: "1" } })).toBe(true);
+      expect(shouldCheckForUpdate({ ...base, env: { [key]: "1" } })).toBe(false);
+    }
+
+    expect(isUpdateNotifierSilenced({ ...notifier, configOptOut: true })).toBe(true);
+  });
+
+  it("stays out of the way on an ordinary launch", () => {
+    expect(isUpdateNotifierSilenced(notifier)).toBe(false);
+  });
+});
+
+describe("updateNotice", () => {
+  it("names both versions and how to take the upgrade", () => {
+    expect(updateNotice("0.3.0", "0.4.0", "npm-global")).toBe(
+      "Lantern 0.4.0 is available (you have 0.3.0). Run `lantern upgrade`.",
+    );
+  });
+
+  it("points a Homebrew install at brew", () => {
+    expect(updateNotice("0.3.0", "0.4.0", "homebrew")).toContain("brew upgrade lantern-viewer");
+  });
+
+  it("says nothing when there is nothing to say", () => {
+    expect(updateNotice("0.3.0", null, "npm-global")).toBeNull();
+    expect(updateNotice("0.3.0", "0.3.0", "npm-global")).toBeNull();
+    expect(updateNotice("0.4.0", "0.3.0", "npm-global")).toBeNull();
+  });
+
+  it("does not nag an install that cannot act on it", () => {
+    expect(updateNotice("0.3.0", "0.4.0", "docker")).toBeNull();
+    expect(updateNotice("0.3.0", "0.4.0", "system-package")).toBeNull();
+  });
+
+  /** A beta on the `latest` tag is not an upgrade for a release install. */
+  it("never offers a prerelease to a stable install", () => {
+    expect(updateNotice("0.3.0", "0.4.0-beta.1", "npm-global")).toBeNull();
+  });
+});
+
+describe("wantsUpdateCheck", () => {
+  const argv = (...args: string[]): string[] => ["node", "/usr/local/bin/lantern", ...args];
+
+  it("runs alongside the commands that stay up", () => {
+    expect(wantsUpdateCheck(argv())).toBe(true);
+    expect(wantsUpdateCheck(argv("browse"))).toBe(true);
+    expect(wantsUpdateCheck(argv("b"))).toBe(true);
+    expect(wantsUpdateCheck(argv("--port", "3400"))).toBe(true);
+  });
+
+  /**
+   * An in-flight request holds the event loop open, so a command that prints
+   * one line and stops would sit there waiting on it.
+   */
+  it("stays out of commands that print and exit", () => {
+    expect(wantsUpdateCheck(argv("--version"))).toBe(false);
+    expect(wantsUpdateCheck(argv("--help"))).toBe(false);
+    expect(wantsUpdateCheck(argv("upgrade"))).toBe(false);
+    expect(wantsUpdateCheck(argv("init"))).toBe(false);
+  });
+
+  /** `--port 3400` is the root command, and 3400 is not a subcommand. */
+  it("does not read an option's value as a command", () => {
+    expect(wantsUpdateCheck(argv("--hostname", "0.0.0.0"))).toBe(true);
+  });
+});

--- a/src/cli/update/updateCheck.ts
+++ b/src/cli/update/updateCheck.ts
@@ -1,0 +1,132 @@
+import { isUpgrade } from "../../lib/version/semver.ts";
+import type { InstallSource } from "../upgrade/installSource.ts";
+
+export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export type UpdateNotifierContext = {
+  /** Whether there is a terminal to write the notice to. */
+  isInteractive: boolean;
+  env: Record<string, string | undefined>;
+  /** Whether `updateNotifier: false` is stored in the settings file. */
+  configOptOut: boolean;
+  installSource: InstallSource["kind"];
+};
+
+export type UpdateCheckContext = UpdateNotifierContext & {
+  /** When the registry was last asked, or null if it never has been. */
+  lastCheckedAt: number | null;
+  now: number;
+  intervalMs: number;
+};
+
+/**
+ * Installs that can act on a notice.
+ *
+ * The rest are told nothing, because there is nothing for them to do with it: a
+ * container replaces an image, a checkout pulls, an npx run already fetched the
+ * newest version, and the retired packages have no newer version to move to —
+ * that one is `lantern upgrade`'s message to deliver once, not a line on every
+ * launch.
+ */
+const NOTIFIABLE: ReadonlySet<InstallSource["kind"]> = new Set([
+  "npm-global",
+  "homebrew",
+  "unknown",
+]);
+
+export const isNotifiable = (kind: InstallSource["kind"]): boolean => NOTIFIABLE.has(kind);
+
+const isSet = (value: string | undefined): boolean => value !== undefined && value !== "";
+
+/**
+ * Whether Lantern should say nothing about versions at all.
+ *
+ * One predicate for both halves — the notice and the request behind it —
+ * because they have to agree: `NO_UPDATE_NOTIFIER` that stopped the request but
+ * still printed yesterday's answer would be a variable that does not do what it
+ * says. Read alongside `shouldRunWizard`: same shape, same rule that an
+ * exported-but-empty variable is not a yes.
+ */
+export const isUpdateNotifierSilenced = ({
+  isInteractive,
+  env,
+  configOptOut,
+  installSource,
+}: UpdateNotifierContext): boolean =>
+  !isInteractive ||
+  configOptOut ||
+  !isNotifiable(installSource) ||
+  isSet(env["CI"]) ||
+  isSet(env["NO_UPDATE_NOTIFIER"]) ||
+  isSet(env["LANTERN_NO_UPDATE_NOTIFIER"]);
+
+/** Whether to ask the registry what has been published, and how long ago it was asked. */
+export const shouldCheckForUpdate = ({
+  lastCheckedAt,
+  now,
+  intervalMs,
+  ...notifier
+}: UpdateCheckContext): boolean => {
+  if (isUpdateNotifierSilenced(notifier)) {
+    return false;
+  }
+
+  if (lastCheckedAt === null) {
+    return true;
+  }
+
+  const elapsed = now - lastCheckedAt;
+
+  // A negative gap means the clock moved back — a restored backup, a laptop
+  // waking up wrong. Asking again costs one request; the alternative is a check
+  // that never runs again.
+  return elapsed < 0 || elapsed >= intervalMs;
+};
+
+/**
+ * The line printed when a newer release is already known about.
+ *
+ * Always from the cache the last check wrote, never from a live request: a
+ * notice that waits on the network is a notice that delays the board.
+ */
+export const updateNotice = (
+  current: string,
+  cached: string | null,
+  installSource: InstallSource["kind"],
+): string | null => {
+  if (cached === null || !isNotifiable(installSource) || !isUpgrade(current, cached)) {
+    return null;
+  }
+
+  const how = installSource === "homebrew" ? "brew upgrade lantern-viewer" : "lantern upgrade";
+
+  return `Lantern ${cached} is available (you have ${current}). Run \`${how}\`.`;
+};
+
+const HELP_FLAGS = new Set(["--version", "-V", "--help", "-h", "help"]);
+/** Every subcommand `registerCliCommands` declares, aliases included. */
+const COMMANDS = new Set(["init", "browse", "b", "upgrade"]);
+/** The ones that stay running long enough to carry a background request. */
+const CHECKED_COMMANDS = new Set(["browse", "b"]);
+
+/**
+ * Whether this invocation is one the check can run alongside.
+ *
+ * Only the two commands that stay running anyway: an in-flight request holds
+ * the event loop open, so firing one from `lantern --version` would leave it
+ * sitting there after it had already said everything it was going to say.
+ */
+export const wantsUpdateCheck = (argv: readonly string[]): boolean => {
+  // node, then the script itself.
+  const args = argv.slice(2);
+
+  if (args.some((arg) => HELP_FLAGS.has(arg))) {
+    return false;
+  }
+
+  // Matched against the command names rather than "the first thing that is not
+  // a flag", because an option's value — `--port 3400` — is not a flag either.
+  const command = args.find((arg) => COMMANDS.has(arg));
+
+  return command === undefined || CHECKED_COMMANDS.has(command);
+};

--- a/src/cli/upgrade/detectInstall.ts
+++ b/src/cli/upgrade/detectInstall.ts
@@ -1,0 +1,103 @@
+import { FileSystem, Path } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Effect } from "effect";
+import { classifyInstallSource, type InstallProbe, type InstallSource } from "./installSource.ts";
+
+const run = <A>(effect: Effect.Effect<A, never, FileSystem.FileSystem | Path.Path>): Promise<A> =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeContext.layer)));
+
+const exists = (path: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+
+    return yield* fs.exists(path).pipe(Effect.catchAll(() => Effect.succeed(false)));
+  });
+
+/**
+ * The directory of the `package.json` this build belongs to.
+ *
+ * Walked rather than assumed: the bundle sits in `dist/` when installed and in
+ * `src/server/` when a checkout runs it from source, and both have to resolve
+ * to the same root for the checkout test to hold.
+ */
+const findPackageRoot = (start: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    let directory = path.dirname(start);
+
+    for (let depth = 0; depth < 10; depth += 1) {
+      if (yield* exists(path.join(directory, "package.json"))) {
+        return directory;
+      }
+
+      const parent = path.dirname(directory);
+      if (parent === directory) {
+        break;
+      }
+      directory = parent;
+    }
+
+    return path.dirname(start);
+  });
+
+/**
+ * Everything the classifier needs, gathered from this machine.
+ *
+ * The entry *module* is resolved rather than `process.argv[1]`: argv[1] is the
+ * shim a package manager wrote onto PATH, and following it back to the real
+ * file is what tells a Cellar from a global `node_modules`.
+ */
+export const detectInstallSource = (): Promise<InstallSource> =>
+  run(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      const scriptPath = yield* fs
+        .realPath(import.meta.filename)
+        .pipe(Effect.catchAll(() => Effect.succeed(import.meta.filename)));
+      const packageRoot = yield* findPackageRoot(scriptPath);
+
+      const [dockerMarker, podmanMarker, gitMarker, dpkg, rpm] = yield* Effect.all([
+        exists("/.dockerenv"),
+        exists("/run/.containerenv"),
+        exists(path.join(packageRoot, ".git")),
+        exists("/usr/bin/dpkg"),
+        exists("/usr/bin/rpm"),
+      ]);
+
+      const probe: InstallProbe = {
+        scriptPath,
+        packageRoot,
+        platform: process.platform,
+        // Read at the boundary, the way the first-run wizard reads it: the
+        // classifier itself stays a function of its arguments.
+        // oxlint-disable-next-line no-process-env
+        env: process.env,
+        containerMarker: dockerMarker || podmanMarker,
+        gitMarker,
+        systemPackageManager: dpkg ? "apt" : rpm ? "dnf" : "unknown",
+      };
+
+      return classifyInstallSource(probe);
+    }),
+  );
+
+/**
+ * Whether this user could replace the tree an upgrade would rewrite.
+ *
+ * Asked before running anything so a root-owned prefix ends in a printed
+ * `sudo …` line rather than a half-finished install — Lantern never elevates
+ * itself.
+ */
+export const isWritable = (directory: string): Promise<boolean> =>
+  run(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+
+      return yield* fs.access(directory, { writable: true }).pipe(
+        Effect.as(true),
+        Effect.catchAll(() => Effect.succeed(false)),
+      );
+    }),
+  );

--- a/src/cli/upgrade/installSource.test.ts
+++ b/src/cli/upgrade/installSource.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { classifyInstallSource, type InstallProbe } from "./installSource.ts";
+
+const base: InstallProbe = {
+  scriptPath: "/usr/local/lib/node_modules/lantern-viewer/dist/main.js",
+  packageRoot: "/usr/local/lib/node_modules/lantern-viewer",
+  platform: "linux",
+  env: {},
+  containerMarker: false,
+  gitMarker: false,
+  systemPackageManager: "unknown",
+};
+
+const probe = (overrides: Partial<InstallProbe>): InstallProbe => ({ ...base, ...overrides });
+
+describe("classifyInstallSource", () => {
+  it("reads a global npm install, and where it lives", () => {
+    expect(classifyInstallSource(base)).toEqual({
+      kind: "npm-global",
+      manager: "npm",
+      root: "/usr/local/lib/node_modules",
+    });
+  });
+
+  it("reads a version-manager install as npm", () => {
+    const source = classifyInstallSource(
+      probe({
+        scriptPath:
+          "/home/u/.nvm/versions/node/v24.4.0/lib/node_modules/lantern-viewer/dist/main.js",
+        packageRoot: "/home/u/.nvm/versions/node/v24.4.0/lib/node_modules/lantern-viewer",
+      }),
+    );
+
+    expect(source).toEqual({
+      kind: "npm-global",
+      manager: "npm",
+      root: "/home/u/.nvm/versions/node/v24.4.0/lib/node_modules",
+    });
+  });
+
+  it("tells the package managers apart by where they keep their global tree", () => {
+    const managers = [
+      {
+        path: "/home/u/.local/share/pnpm/global/5/node_modules/lantern-viewer/dist/main.js",
+        manager: "pnpm",
+      },
+      {
+        path: "/home/u/.config/yarn/global/node_modules/lantern-viewer/dist/main.js",
+        manager: "yarn",
+      },
+      {
+        path: "/home/u/.bun/install/global/node_modules/lantern-viewer/dist/main.js",
+        manager: "bun",
+      },
+    ];
+
+    for (const { path, manager } of managers) {
+      const source = classifyInstallSource(probe({ scriptPath: path }));
+
+      expect(source.kind).toBe("npm-global");
+      expect(source.kind === "npm-global" ? source.manager : null).toBe(manager);
+    }
+  });
+
+  /** Windows writes the same tree with the other separator, under AppData. */
+  it("reads a global npm install on Windows", () => {
+    const source = classifyInstallSource(
+      probe({
+        scriptPath:
+          "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\lantern-viewer\\dist\\main.js",
+        packageRoot: "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\lantern-viewer",
+        platform: "win32",
+      }),
+    );
+
+    expect(source).toEqual({
+      kind: "npm-global",
+      manager: "npm",
+      root: "C:/Users/u/AppData/Roaming/npm/node_modules",
+    });
+  });
+
+  it("reads a Homebrew install, on either prefix", () => {
+    const prefixes = ["/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew"];
+
+    for (const prefix of prefixes) {
+      const source = classifyInstallSource(
+        probe({
+          scriptPath: `${prefix}/Cellar/lantern-viewer/0.3.0/libexec/lib/node_modules/lantern-viewer/dist/main.js`,
+        }),
+      );
+
+      expect(source).toEqual({ kind: "homebrew", prefix });
+    }
+  });
+
+  /**
+   * The formula's tree *is* an npm install, so the Cellar has to be recognised
+   * first — otherwise a `brew` user is told to run `npm install -g`, which
+   * would leave two Lanterns on PATH.
+   */
+  it("calls a Cellar under /usr/local Homebrew, not npm", () => {
+    const source = classifyInstallSource(
+      probe({
+        scriptPath:
+          "/usr/local/Cellar/lantern-viewer/0.3.0/libexec/lib/node_modules/lantern-viewer/dist/main.js",
+      }),
+    );
+
+    expect(source.kind).toBe("homebrew");
+  });
+
+  it("reads the retired deb and rpm layout, and which tool would remove it", () => {
+    expect(
+      classifyInstallSource(
+        probe({
+          scriptPath: "/usr/lib/lantern/dist/main.js",
+          packageRoot: "/usr/lib/lantern",
+          systemPackageManager: "apt",
+        }),
+      ),
+    ).toEqual({ kind: "system-package", manager: "apt" });
+  });
+
+  it("reads a container by its marker file", () => {
+    expect(
+      classifyInstallSource(
+        probe({ scriptPath: "/app/dist/main.js", packageRoot: "/app", containerMarker: true }),
+      ),
+    ).toEqual({ kind: "docker" });
+  });
+
+  /** Podman and containerd write no /.dockerenv; Lantern's own image is still /app. */
+  it("reads Lantern's own image without a marker file", () => {
+    expect(
+      classifyInstallSource(
+        probe({
+          scriptPath: "/app/dist/main.js",
+          packageRoot: "/app",
+          env: { LANTERN_ENV: "production" },
+        }),
+      ),
+    ).toEqual({ kind: "docker" });
+  });
+
+  /**
+   * A devcontainer, a CI image, somebody's own Dockerfile: a global install
+   * inside one is still a global install, and its owner upgrades it the way
+   * anybody else would. Only Lantern's own image is beyond upgrading.
+   */
+  it("does not mistake every container for Lantern's image", () => {
+    const npmInAContainer = classifyInstallSource(probe({ containerMarker: true }));
+    const debInAContainer = classifyInstallSource(
+      probe({
+        scriptPath: "/usr/lib/lantern/dist/main.js",
+        packageRoot: "/usr/lib/lantern",
+        containerMarker: true,
+        systemPackageManager: "apt",
+      }),
+    );
+
+    expect(npmInAContainer.kind).toBe("npm-global");
+    expect(debInAContainer.kind).toBe("system-package");
+  });
+
+  it("reads a one-off npx run", () => {
+    const caches = [
+      "/home/u/.npm/_npx/1a2b3c/node_modules/lantern-viewer/dist/main.js",
+      "/home/u/.local/share/pnpm/dlx-1a2b3c/node_modules/lantern-viewer/dist/main.js",
+      "/home/u/.bun/install/cache/lantern-viewer@0.3.0/dist/main.js",
+    ];
+
+    for (const path of caches) {
+      expect(classifyInstallSource(probe({ scriptPath: path })).kind).toBe("npx-cache");
+    }
+  });
+
+  it("reads a git checkout, built or run from source", () => {
+    const built = classifyInstallSource(
+      probe({
+        scriptPath: "/home/u/code/lantern/dist/main.js",
+        packageRoot: "/home/u/code/lantern",
+        gitMarker: true,
+      }),
+    );
+    const source = classifyInstallSource(
+      probe({
+        scriptPath: "/home/u/code/lantern/src/server/main.ts",
+        packageRoot: "/home/u/code/lantern",
+        gitMarker: true,
+      }),
+    );
+
+    expect(built).toEqual({ kind: "git-checkout", root: "/home/u/code/lantern" });
+    expect(source).toEqual({ kind: "git-checkout", root: "/home/u/code/lantern" });
+  });
+
+  /**
+   * A checkout can live anywhere, including inside a prefix that would
+   * otherwise read as an install.
+   */
+  it("prefers the checkout to the path it happens to sit in", () => {
+    const source = classifyInstallSource(
+      probe({
+        scriptPath: "/usr/local/lib/node_modules/lantern-viewer/dist/main.js",
+        packageRoot: "/usr/local/lib/node_modules/lantern-viewer",
+        gitMarker: true,
+      }),
+    );
+
+    expect(source.kind).toBe("git-checkout");
+  });
+
+  it("keeps the path when it cannot tell, so the message can show it", () => {
+    expect(classifyInstallSource(probe({ scriptPath: "/opt/weird/lantern/main.js" }))).toEqual({
+      kind: "unknown",
+      path: "/opt/weird/lantern/main.js",
+    });
+  });
+});

--- a/src/cli/upgrade/installSource.ts
+++ b/src/cli/upgrade/installSource.ts
@@ -1,0 +1,135 @@
+import packageJson from "../../../package.json" with { type: "json" };
+
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+/** Where this copy of Lantern came from, and what could replace it. */
+export type InstallSource =
+  | {
+      kind: "npm-global";
+      manager: PackageManager;
+      /** The global `node_modules` holding Lantern — what the upgrade rewrites. */
+      root: string;
+    }
+  | { kind: "npx-cache" }
+  | { kind: "homebrew"; prefix: string }
+  | { kind: "system-package"; manager: "apt" | "dnf" | "unknown" }
+  | { kind: "docker" }
+  | { kind: "git-checkout"; root: string }
+  | { kind: "unknown"; path: string };
+
+export type InstallProbe = {
+  /** The running entry module, with every symlink resolved. */
+  scriptPath: string;
+  /** Directory of the nearest `package.json` above it. */
+  packageRoot: string;
+  platform: NodeJS.Platform;
+  env: Record<string, string | undefined>;
+  /** Whether `/.dockerenv` or `/run/.containerenv` is there. */
+  containerMarker: boolean;
+  /** Whether a `.git` entry sits beside `packageRoot`. */
+  gitMarker: boolean;
+  /** Which tool owns system packages here, so a refusal can name the remover. */
+  systemPackageManager: "apt" | "dnf" | "unknown";
+};
+
+const PACKAGE_SEGMENT = `/node_modules/${packageJson.name}/`;
+const CELLAR_SEGMENT = "/Cellar/";
+const SYSTEM_PACKAGE_PREFIX = "/usr/lib/lantern/";
+const CONTAINER_IMAGE_PREFIX = "/app/";
+
+/** Windows writes the same trees with the other separator; nothing below cares which. */
+const normalise = (path: string): string => path.replaceAll("\\", "/");
+
+const NPX_CACHE_SEGMENTS = [
+  // npm: ~/.npm/_npx/<hash>/node_modules/…
+  "/_npx/",
+  // pnpm: ~/.local/share/pnpm/dlx-<hash>/node_modules/…
+  "/dlx-",
+  // bun: ~/.bun/install/cache/<package>@<version>/…
+  "/.bun/install/cache/",
+];
+
+const GLOBAL_ROOTS: ReadonlyArray<{ manager: PackageManager; segments: readonly string[] }> = [
+  { manager: "pnpm", segments: ["/pnpm/global/"] },
+  { manager: "yarn", segments: ["/yarn/global/", "/.yarn/global/"] },
+  { manager: "bun", segments: ["/.bun/install/global/"] },
+];
+
+/**
+ * Which package manager put this tree here, from the shape of the path.
+ *
+ * Not `npm_config_user_agent`: that is only set when a package manager spawned
+ * the process, and nobody upgrades Lantern by asking npm to run it. The global
+ * root each manager writes to is the one signal that survives being launched
+ * from a shell.
+ */
+const globalManager = (path: string): PackageManager => {
+  for (const { manager, segments } of GLOBAL_ROOTS) {
+    if (segments.some((segment) => path.includes(segment))) {
+      return manager;
+    }
+  }
+
+  // Everything else is npm's: /usr/local/lib/node_modules, ~/.npm-global, the
+  // per-version trees nvm and fnm keep, and %APPDATA%\npm on Windows.
+  return "npm";
+};
+
+/**
+ * Works out how Lantern was installed, from paths alone.
+ *
+ * Kept pure and away from the probing so the cases nobody can reproduce on
+ * their own machine — a Cellar, a container built from the retired deb, yarn's
+ * global root — are settled in tests. The order below is load-bearing and each
+ * step says why it comes where it does.
+ */
+export const classifyInstallSource = (probe: InstallProbe): InstallSource => {
+  const path = normalise(probe.scriptPath);
+
+  // Lantern's *own* image, first: nothing inside it can be upgraded, only
+  // replaced by pulling a newer one. It is deliberately narrower than "some
+  // container" — a devcontainer or a CI image with a global npm install is a
+  // normal install that happens to be containerised, and telling its owner to
+  // pull an image they do not run would be worse than useless. The two tests
+  // are the marker file and, for Podman and containerd which write none, the
+  // /app tree and environment the Dockerfile bakes in.
+  if (
+    path.startsWith(CONTAINER_IMAGE_PREFIX) &&
+    (probe.containerMarker || probe.env["LANTERN_ENV"] === "production")
+  ) {
+    return { kind: "docker" };
+  }
+
+  // Before any path test: a checkout can be anywhere, including inside a prefix
+  // that would otherwise read as an install. This keys off the package root
+  // rather than the entry name, so `pnpm dev:backend` lands here too.
+  if (probe.gitMarker) {
+    return { kind: "git-checkout", root: normalise(probe.packageRoot) };
+  }
+
+  if (NPX_CACHE_SEGMENTS.some((segment) => path.includes(segment))) {
+    return { kind: "npx-cache" };
+  }
+
+  // Ahead of the npm test on purpose: the formula installs an npm tree inside
+  // the Cellar, so both match, and only one of them can be upgraded safely.
+  const cellar = path.indexOf(CELLAR_SEGMENT);
+  if (cellar !== -1) {
+    return { kind: "homebrew", prefix: path.slice(0, cellar) };
+  }
+
+  if (path.startsWith(SYSTEM_PACKAGE_PREFIX)) {
+    return { kind: "system-package", manager: probe.systemPackageManager };
+  }
+
+  const packageSegment = path.indexOf(PACKAGE_SEGMENT);
+  if (packageSegment !== -1) {
+    const root = path.slice(0, packageSegment + "/node_modules".length);
+
+    return { kind: "npm-global", manager: globalManager(path), root };
+  }
+
+  // Reported as-is rather than normalised: this one is shown to the user, who
+  // has to recognise it as a path on their own machine.
+  return { kind: "unknown", path: probe.scriptPath };
+};

--- a/src/cli/upgrade/runUpgradeCommand.test.ts
+++ b/src/cli/upgrade/runUpgradeCommand.test.ts
@@ -1,0 +1,23 @@
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import { describe, expect } from "vitest";
+import { runUpgradeCommand } from "./runUpgradeCommand.ts";
+
+describe("runUpgradeCommand", () => {
+  /**
+   * The exit code is the whole report: the package manager's output went
+   * straight to the terminal, so this is the only thing Lantern learns from it.
+   */
+  it.live("waits for the package manager and reports how it ended", () =>
+    Effect.promise(async () => {
+      expect(await runUpgradeCommand("sh", ["-c", "exit 0"])).toBe(0);
+      expect(await runUpgradeCommand("sh", ["-c", "exit 3"])).toBe(3);
+    }),
+  );
+
+  it.live("comes back with a code when the package manager is not there at all", () =>
+    Effect.promise(async () => {
+      expect(await runUpgradeCommand("lantern-no-such-package-manager", [])).toBe(127);
+    }),
+  );
+});

--- a/src/cli/upgrade/runUpgradeCommand.ts
+++ b/src/cli/upgrade/runUpgradeCommand.ts
@@ -1,0 +1,33 @@
+import { Command, type CommandExecutor } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Effect } from "effect";
+
+const run = <A, E>(effect: Effect.Effect<A, E, CommandExecutor.CommandExecutor>): Promise<A> =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeContext.layer)));
+
+/**
+ * Hands the terminal to the package manager and reports how it went.
+ *
+ * The child inherits the terminal rather than being captured: `npm install -g`
+ * takes tens of seconds and writes progress as it goes, and buffering that
+ * would leave the user watching nothing. The cost is that Lantern cannot read
+ * the failure text, which is why a non-zero exit prints a fixed remediation
+ * block instead of quoting the error.
+ *
+ * No working directory is set. A global install must not depend on where it was
+ * started from, and leaving the directory alone lets a local `.npmrc` — a
+ * registry mirror, a proxy — apply exactly as it would if the user had typed
+ * the command.
+ */
+export const runUpgradeCommand = (binary: string, args: readonly string[]): Promise<number> =>
+  run(
+    Command.make(binary, ...args).pipe(
+      Command.stdin("inherit"),
+      Command.stdout("inherit"),
+      Command.stderr("inherit"),
+      Command.exitCode,
+      // A package manager that is not on PATH has to come back as a code the
+      // command can report, not as a rejected promise.
+      Effect.catchAll(() => Effect.succeed(127)),
+    ),
+  );

--- a/src/cli/upgrade/upgradeCommand.test.ts
+++ b/src/cli/upgrade/upgradeCommand.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseUpgradeOptions, renderUpgradePlan } from "./upgradeCommand.ts";
+
+describe("parseUpgradeOptions", () => {
+  it("reads the flags the command declares", () => {
+    expect(parseUpgradeOptions({ check: true, dryRun: true })).toEqual({
+      check: true,
+      dryRun: true,
+    });
+  });
+
+  it("falls back to neither rather than trusting a stray option bag", () => {
+    expect(parseUpgradeOptions({ check: "yes" })).toEqual({});
+    expect(parseUpgradeOptions(undefined)).toEqual({});
+  });
+});
+
+describe("renderUpgradePlan", () => {
+  it("prints the command a refusal is pointing at", () => {
+    const text = renderUpgradePlan({
+      kind: "refused",
+      reason: "Lantern was installed by Homebrew (/opt/homebrew).",
+      commands: ["brew update && brew upgrade lantern-viewer"],
+      note: null,
+    });
+
+    expect(text).toContain("  brew update && brew upgrade lantern-viewer");
+    expect(text).toContain("Nothing was changed.");
+  });
+
+  it("shows both versions when there is an upgrade to take", () => {
+    const text = renderUpgradePlan({
+      kind: "available",
+      from: "0.3.0",
+      to: "0.4.0",
+      binary: "npm",
+      args: ["install", "-g", "lantern-viewer@latest"],
+    });
+
+    expect(text).toContain("0.4.0 is available (you have 0.3.0)");
+    expect(text).toContain("  npm install -g lantern-viewer@latest");
+  });
+
+  it("says nothing is needed when the newest release is the one installed", () => {
+    expect(renderUpgradePlan({ kind: "up-to-date", version: "0.3.0" })).toBe(
+      "Lantern 0.3.0 is the latest release.",
+    );
+  });
+});

--- a/src/cli/upgrade/upgradeCommand.ts
+++ b/src/cli/upgrade/upgradeCommand.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import packageJson from "../../../package.json" with { type: "json" };
+import { fetchLatestVersion } from "../update/latestVersion.ts";
+import { detectInstallSource, isWritable } from "./detectInstall.ts";
+import type { InstallSource } from "./installSource.ts";
+import { runUpgradeCommand } from "./runUpgradeCommand.ts";
+import { commandText, makeUpgradePlan, type UpgradePlan } from "./upgradePlan.ts";
+
+/**
+ * `upgrade` declares its own flags, and only its own.
+ *
+ * The opposite of `src/cli/commandOptions.ts`: `--check` and `--dry-run` exist
+ * nowhere else, so the subcommand's own `opts()` is the whole story and reading
+ * the root's would only let an unrelated flag through.
+ */
+const upgradeOptionsSchema = z.object({
+  check: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
+});
+
+export type UpgradeCommandOptions = z.infer<typeof upgradeOptionsSchema>;
+
+export const parseUpgradeOptions = (raw: unknown): UpgradeCommandOptions => {
+  const result = upgradeOptionsSchema.safeParse(raw);
+
+  return result.success ? result.data : {};
+};
+
+const indent = (commands: readonly string[]): string =>
+  commands.map((command) => `  ${command}`).join("\n");
+
+/** What the user reads. Kept pure so the wording is settled in tests. */
+export const renderUpgradePlan = (plan: UpgradePlan): string => {
+  switch (plan.kind) {
+    case "up-to-date":
+      return `Lantern ${plan.version} is the latest release.`;
+
+    case "available":
+      return [
+        `Lantern ${plan.to} is available (you have ${plan.from}).`,
+        "",
+        indent([commandText({ binary: plan.binary, args: plan.args })]),
+      ].join("\n");
+
+    case "run":
+      return `Upgrading Lantern ${plan.from} → ${plan.to}.`;
+
+    case "refused":
+      return [
+        plan.reason,
+        "",
+        indent(plan.commands),
+        "",
+        ...(plan.note === null ? [] : [plan.note]),
+        "Nothing was changed.",
+      ].join("\n");
+
+    case "unreachable":
+      return `${plan.reason}\nNothing was changed.`;
+
+    default:
+      plan satisfies never;
+      return "";
+  }
+};
+
+/**
+ * What to do when the package manager gives up.
+ *
+ * The child owned the terminal, so its error text went to the user and not to
+ * Lantern. Naming the two failures that actually happen — a tree the package
+ * manager could not replace because this process is running out of it — is
+ * worth more than a generic "it failed".
+ */
+const remediation = (binary: string, command: string, code: number): string =>
+  [
+    `The upgrade did not finish (${binary} exited ${code}).`,
+    "",
+    "If it mentioned ENOTEMPTY or EPERM, the package manager could not replace a",
+    "tree Lantern is running from. Close this process and run it again:",
+    "",
+    indent([command]),
+  ].join("\n");
+
+const needsRegistry = (source: InstallSource): boolean =>
+  source.kind === "npm-global" || source.kind === "npx-cache";
+
+/**
+ * Upgrades Lantern where it was installed, or says what would.
+ *
+ * Plain output rather than an Ink screen: this has to work over `ssh host
+ * lantern upgrade` and inside a script, and the package manager writes to the
+ * same terminal while it runs — two things an alternate-screen render cannot
+ * share.
+ */
+export const runUpgrade = async (options: UpgradeCommandOptions): Promise<number> => {
+  const source = await detectInstallSource();
+  const latest = needsRegistry(source) ? await fetchLatestVersion() : null;
+  const rootWritable = source.kind === "npm-global" ? await isWritable(source.root) : true;
+
+  const plan = makeUpgradePlan({
+    source,
+    current: packageJson.version,
+    latest,
+    dryRun: options.dryRun === true,
+    checkOnly: options.check === true,
+    rootWritable,
+  });
+
+  process.stdout.write(`${renderUpgradePlan(plan)}\n`);
+
+  if (plan.kind === "refused" || plan.kind === "unreachable") {
+    return 1;
+  }
+
+  if (plan.kind !== "run") {
+    return 0;
+  }
+
+  const command = commandText({ binary: plan.binary, args: plan.args });
+  const code = await runUpgradeCommand(plan.binary, plan.args);
+
+  if (code !== 0) {
+    process.stderr.write(`\n${remediation(plan.binary, command, code)}\n`);
+
+    return code;
+  }
+
+  // Deliberately the last thing this build does: the new version is on disk,
+  // but this process is still the old one, and re-executing it would run code
+  // from a tree that was replaced underneath it.
+  process.stdout.write(
+    `\nUpgraded to ${plan.to}. Run \`lantern --version\` to confirm, then start it again.\n`,
+  );
+
+  return 0;
+};

--- a/src/cli/upgrade/upgradePlan.test.ts
+++ b/src/cli/upgrade/upgradePlan.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { InstallSource, PackageManager } from "./installSource.ts";
+import { makeUpgradePlan, type UpgradePlan } from "./upgradePlan.ts";
+
+const npmGlobal = (manager: PackageManager): InstallSource => ({
+  kind: "npm-global",
+  manager,
+  root: "/usr/local/lib/node_modules",
+});
+
+const plan = (
+  source: InstallSource,
+  overrides: Partial<Parameters<typeof makeUpgradePlan>[0]> = {},
+): UpgradePlan =>
+  makeUpgradePlan({
+    source,
+    current: "0.3.0",
+    latest: "0.4.0",
+    dryRun: false,
+    checkOnly: false,
+    rootWritable: true,
+    ...overrides,
+  });
+
+const commandLine = (result: UpgradePlan): string =>
+  result.kind === "run" || result.kind === "available"
+    ? [result.binary, ...result.args].join(" ")
+    : "";
+
+describe("makeUpgradePlan", () => {
+  /**
+   * The verbs differ between package managers: `pnpm install -g` and
+   * `bun install -g` are not commands, and yarn 2 removed `yarn global`
+   * altogether. Printing one of those would be worse than refusing.
+   */
+  it("names the command each package manager actually takes", () => {
+    expect(commandLine(plan(npmGlobal("npm")))).toBe("npm install -g lantern-viewer@latest");
+    expect(commandLine(plan(npmGlobal("pnpm")))).toBe("pnpm add -g lantern-viewer@latest");
+    expect(commandLine(plan(npmGlobal("bun")))).toBe("bun add -g lantern-viewer@latest");
+    expect(commandLine(plan(npmGlobal("yarn")))).toBe("yarn global add lantern-viewer@latest");
+  });
+
+  it("runs the upgrade when there is one to run", () => {
+    const result = plan(npmGlobal("npm"));
+
+    expect(result.kind).toBe("run");
+    expect(result.kind === "run" ? [result.from, result.to] : null).toEqual(["0.3.0", "0.4.0"]);
+  });
+
+  it("says so when the installed version is already the published one", () => {
+    expect(plan(npmGlobal("npm"), { latest: "0.3.0" })).toEqual({
+      kind: "up-to-date",
+      version: "0.3.0",
+    });
+  });
+
+  it("stays put when the registry could not be reached", () => {
+    expect(plan(npmGlobal("npm"), { latest: null }).kind).toBe("unreachable");
+  });
+
+  /** A beta on the `latest` tag is not an upgrade for somebody on a release. */
+  it("does not offer a prerelease to a stable install", () => {
+    expect(plan(npmGlobal("npm"), { latest: "0.4.0-beta.1" }).kind).toBe("up-to-date");
+  });
+
+  it("reports without running for --check and --dry-run", () => {
+    for (const overrides of [{ checkOnly: true }, { dryRun: true }]) {
+      const result = plan(npmGlobal("npm"), overrides);
+
+      expect(result.kind).toBe("available");
+      expect(commandLine(result)).toBe("npm install -g lantern-viewer@latest");
+    }
+  });
+
+  /** Lantern never runs `sudo` for the user; it says which command needs it. */
+  it("refuses rather than escalating when the install is not writable", () => {
+    const result = plan(npmGlobal("npm"), { rootWritable: false });
+
+    expect(result.kind).toBe("refused");
+    expect(result.kind === "refused" ? result.commands : []).toEqual([
+      "sudo npm install -g lantern-viewer@latest",
+    ]);
+  });
+
+  it("leaves an install it did not make alone, and says what would upgrade it", () => {
+    const cases: ReadonlyArray<{ source: InstallSource; command: string }> = [
+      { source: { kind: "homebrew", prefix: "/opt/homebrew" }, command: "brew upgrade" },
+      { source: { kind: "system-package", manager: "apt" }, command: "sudo apt remove lantern" },
+      { source: { kind: "system-package", manager: "dnf" }, command: "sudo dnf remove lantern" },
+      { source: { kind: "docker" }, command: "docker pull" },
+      { source: { kind: "npx-cache" }, command: "npm install -g lantern-viewer" },
+      { source: { kind: "git-checkout", root: "/home/u/code/lantern" }, command: "git pull" },
+      { source: { kind: "unknown", path: "/opt/weird/main.js" }, command: "npm install -g" },
+    ];
+
+    for (const { source, command } of cases) {
+      const result = plan(source);
+
+      expect(result.kind).toBe("refused");
+      expect(result.kind === "refused" ? result.commands.join("\n") : "").toContain(command);
+    }
+  });
+
+  /**
+   * The retired channels are the reason this command exists: a .deb user has to
+   * be told the packages have stopped, not merely that Lantern will not touch
+   * them.
+   */
+  it("tells a deb or rpm install how to move to npm", () => {
+    const result = plan({ kind: "system-package", manager: "apt" });
+    const text = result.kind === "refused" ? `${result.reason}\n${result.commands.join("\n")}` : "";
+
+    expect(text).toContain("retired");
+    expect(text).toContain("npm install -g lantern-viewer");
+  });
+
+  it("gives every refusal something the user can act on", () => {
+    const sources: readonly InstallSource[] = [
+      { kind: "homebrew", prefix: "/opt/homebrew" },
+      { kind: "system-package", manager: "unknown" },
+      { kind: "docker" },
+      { kind: "npx-cache" },
+      { kind: "git-checkout", root: "/home/u/code/lantern" },
+      { kind: "unknown", path: "/opt/weird/main.js" },
+    ];
+
+    for (const source of sources) {
+      const result = plan(source);
+
+      expect(result.kind === "refused" ? result.reason.length > 0 : false).toBe(true);
+      expect(result.kind === "refused" ? result.commands.length > 0 : false).toBe(true);
+    }
+  });
+
+  /** Nothing this command does to a foreign install depends on the registry. */
+  it("still explains a foreign install when the registry is unreachable", () => {
+    expect(plan({ kind: "docker" }, { latest: null }).kind).toBe("refused");
+  });
+});

--- a/src/cli/upgrade/upgradePlan.ts
+++ b/src/cli/upgrade/upgradePlan.ts
@@ -1,0 +1,200 @@
+import packageJson from "../../../package.json" with { type: "json" };
+import { isUpgrade } from "../../lib/version/semver.ts";
+import type { InstallSource, PackageManager } from "./installSource.ts";
+
+const PACKAGE = packageJson.name;
+const IMAGE = "ghcr.io/wildchildforlife/lantern:latest";
+const ISSUES_URL = "https://github.com/WildChildForLife/lantern/issues";
+
+export type UpgradeCommand = { binary: string; args: readonly string[] };
+
+export type UpgradePlan =
+  | { kind: "up-to-date"; version: string }
+  /** There is a newer release, and the user asked to be told rather than moved. */
+  | { kind: "available"; from: string; to: string; binary: string; args: readonly string[] }
+  | { kind: "run"; from: string; to: string; binary: string; args: readonly string[] }
+  | {
+      kind: "refused";
+      reason: string;
+      /** What the user should run instead, one command per line. */
+      commands: readonly string[];
+      note: string | null;
+    }
+  | { kind: "unreachable"; reason: string };
+
+export type UpgradeRequest = {
+  source: InstallSource;
+  /** The version running now. */
+  current: string;
+  /** The version on the registry, or null when it could not be asked. */
+  latest: string | null;
+  dryRun: boolean;
+  checkOnly: boolean;
+  /** Whether this user can write to the tree the upgrade would replace. */
+  rootWritable: boolean;
+};
+
+/**
+ * The install command each package manager takes.
+ *
+ * Spelled out rather than templated, because the verbs genuinely differ:
+ * `pnpm install -g` and `bun install -g` are not commands, and yarn 2 dropped
+ * `yarn global` — which is safe here only because the detector reaches `yarn`
+ * through the yarn 1 global root and nothing else.
+ */
+const installCommand = (manager: PackageManager): UpgradeCommand => {
+  const target = `${PACKAGE}@latest`;
+
+  switch (manager) {
+    case "npm":
+      return { binary: "npm", args: ["install", "-g", target] };
+    case "pnpm":
+      return { binary: "pnpm", args: ["add", "-g", target] };
+    case "bun":
+      return { binary: "bun", args: ["add", "-g", target] };
+    case "yarn":
+      return { binary: "yarn", args: ["global", "add", target] };
+    default:
+      manager satisfies never;
+      return { binary: "npm", args: ["install", "-g", target] };
+  }
+};
+
+export const commandText = (command: UpgradeCommand): string =>
+  [command.binary, ...command.args].join(" ");
+
+const removeCommand = (manager: "apt" | "dnf" | "unknown"): string | null =>
+  manager === "unknown" ? null : `sudo ${manager} remove lantern`;
+
+/**
+ * Why Lantern will not upgrade this install, and what will.
+ *
+ * Every branch names a command. A refusal that only says no leaves the user
+ * with an out-of-date Lantern and nowhere to go, which is worse than the
+ * ENOTEMPTY this is avoiding.
+ */
+const refuse = (source: InstallSource, latest: string | null): UpgradePlan => {
+  switch (source.kind) {
+    case "system-package": {
+      const remove = removeCommand(source.manager);
+
+      return {
+        kind: "refused",
+        reason: [
+          "Lantern was installed from a .deb or .rpm (/usr/lib/lantern).",
+          "",
+          "That channel has been retired: no newer version is published there,",
+          "so this install will stay where it is.",
+          "",
+          "Move to npm — the same build, and `lantern upgrade` keeps it current",
+          "from then on:",
+        ].join("\n"),
+        commands: [...(remove === null ? [] : [remove]), `npm install -g ${PACKAGE}`],
+        note:
+          remove === null
+            ? "Remove the system package first, with whatever installed it. Your settings and cache in ~/.lantern survive both steps."
+            : "Your settings and cache in ~/.lantern survive both steps.",
+      };
+    }
+
+    case "homebrew":
+      return {
+        kind: "refused",
+        reason: `Lantern was installed by Homebrew (${source.prefix}).\nUpgrade it with the tool that installed it:`,
+        commands: [`brew update && brew upgrade ${PACKAGE}`],
+        note: null,
+      };
+
+    case "docker":
+      return {
+        kind: "refused",
+        reason: "Lantern is running inside a container. Upgrade the image instead:",
+        commands: [`docker pull ${IMAGE}`, "docker compose up -d"],
+        note: "Or re-run the `docker run` line you started it with.",
+      };
+
+    case "npx-cache":
+      return {
+        kind: "refused",
+        reason: [
+          "This is a one-off `npx` run, so there is nothing installed to upgrade" +
+            (latest === null ? "." : ` —`),
+          ...(latest === null ? [] : [`npx already fetched the latest release (${latest}).`]),
+          "",
+          "For a permanent install that `lantern upgrade` can keep current:",
+        ].join("\n"),
+        commands: [`npm install -g ${PACKAGE}`],
+        note: null,
+      };
+
+    case "git-checkout":
+      return {
+        kind: "refused",
+        reason: `Lantern is running from a git checkout (${source.root}).\nUpgrade it the way you built it:`,
+        commands: ["git pull && pnpm install && pnpm build"],
+        note: null,
+      };
+
+    case "unknown":
+      return {
+        kind: "refused",
+        reason: `Lantern could not work out how it was installed (${source.path}).\nThe npm install is:`,
+        commands: [`npm install -g ${PACKAGE}@latest`],
+        note: `If you did install it with npm, that is a gap worth closing — please open an issue with the path above: ${ISSUES_URL}`,
+      };
+
+    case "npm-global":
+      return {
+        kind: "refused",
+        reason: `Lantern is installed under ${source.root}, which this user cannot write to.\nRun the upgrade with the privileges that installed it:`,
+        commands: [`sudo ${commandText(installCommand(source.manager))}`],
+        note: null,
+      };
+
+    default:
+      source satisfies never;
+      return {
+        kind: "refused",
+        reason: "Lantern could not work out how it was installed.\nThe npm install is:",
+        commands: [`npm install -g ${PACKAGE}@latest`],
+        note: null,
+      };
+  }
+};
+
+/**
+ * Decides what `lantern upgrade` should do, without doing any of it.
+ *
+ * Split from the doing so the cases that are awkward to reach on a developer's
+ * own machine — a read-only prefix, a Homebrew install, a beta on the `latest`
+ * tag — are settled in tests rather than by spawning a package manager.
+ */
+export const makeUpgradePlan = (request: UpgradeRequest): UpgradePlan => {
+  const { source, current, latest } = request;
+
+  if (source.kind !== "npm-global") {
+    return refuse(source, latest);
+  }
+
+  if (latest === null) {
+    return {
+      kind: "unreachable",
+      reason: "Lantern could not reach the npm registry to see what has been published.",
+    };
+  }
+
+  if (!isUpgrade(current, latest)) {
+    return { kind: "up-to-date", version: current };
+  }
+
+  if (!request.rootWritable) {
+    return refuse(source, latest);
+  }
+
+  const command = installCommand(source.manager);
+  const move = { from: current, to: latest, binary: command.binary, args: command.args };
+
+  return request.checkOnly || request.dryRun
+    ? { kind: "available", ...move }
+    : { kind: "run", ...move };
+};

--- a/src/lib/version/semver.test.ts
+++ b/src/lib/version/semver.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { isUpgrade, parseVersion } from "./semver.ts";
+
+describe("parseVersion", () => {
+  it("reads a release and a prerelease", () => {
+    expect(parseVersion("0.3.0")).toEqual({ major: 0, minor: 3, patch: 0, prerelease: null });
+    expect(parseVersion("1.2.3-beta.10")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: "beta.10",
+    });
+  });
+
+  it("refuses what it cannot read", () => {
+    expect(parseVersion("")).toBeNull();
+    expect(parseVersion("latest")).toBeNull();
+    expect(parseVersion("1.2")).toBeNull();
+  });
+});
+
+describe("isUpgrade", () => {
+  it("compares numerically, not as text", () => {
+    expect(isUpgrade("0.9.0", "0.10.0")).toBe(true);
+    expect(isUpgrade("0.10.0", "0.9.0")).toBe(false);
+    expect(isUpgrade("1.0.0", "1.0.1")).toBe(true);
+  });
+
+  it("is not an upgrade to the version already installed", () => {
+    expect(isUpgrade("0.3.0", "0.3.0")).toBe(false);
+  });
+
+  /**
+   * The one that matters: a beta published to the `latest` tag must never be
+   * offered to somebody running a release.
+   */
+  it("never offers a prerelease to a stable install", () => {
+    expect(isUpgrade("0.3.0", "0.4.0-beta.1")).toBe(false);
+    expect(isUpgrade("0.3.0", "1.0.0-rc.1")).toBe(false);
+  });
+
+  it("offers a newer prerelease to somebody already on one", () => {
+    expect(isUpgrade("0.4.0-beta.1", "0.4.0-beta.2")).toBe(true);
+    expect(isUpgrade("0.4.0-beta.2", "0.4.0-beta.1")).toBe(false);
+    expect(isUpgrade("0.4.0-beta.1", "0.5.0-beta.1")).toBe(true);
+  });
+
+  /** A release always beats the prerelease of the same version. */
+  it("offers the release to somebody on its prerelease", () => {
+    expect(isUpgrade("0.4.0-beta.1", "0.4.0")).toBe(true);
+    expect(isUpgrade("0.4.0", "0.4.0-beta.1")).toBe(false);
+  });
+
+  it("orders prerelease identifiers the way semver does", () => {
+    expect(isUpgrade("1.0.0-alpha.1", "1.0.0-alpha.2")).toBe(true);
+    expect(isUpgrade("1.0.0-alpha.9", "1.0.0-alpha.10")).toBe(true);
+    expect(isUpgrade("1.0.0-alpha", "1.0.0-beta")).toBe(true);
+    expect(isUpgrade("1.0.0-beta", "1.0.0-alpha")).toBe(false);
+  });
+
+  it("stays quiet when either version cannot be read", () => {
+    expect(isUpgrade("not-a-version", "0.4.0")).toBe(false);
+    expect(isUpgrade("0.3.0", "not-a-version")).toBe(false);
+  });
+});

--- a/src/lib/version/semver.ts
+++ b/src/lib/version/semver.ts
@@ -1,0 +1,134 @@
+/**
+ * Enough of semver to decide whether the registry is offering something newer.
+ *
+ * Deliberately not the Claude Code version model in
+ * `src/server/core/claude-code/models/ClaudeCode*`: that one drops the
+ * prerelease part entirely, which is exactly the piece this has to get right —
+ * a beta on the `latest` tag must not be offered to somebody on a release.
+ */
+export type SemanticVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  /** The `-beta.1` part, without its dash, or null for a release. */
+  prerelease: string | null;
+};
+
+const versionPattern =
+  /^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>[0-9A-Za-z-.]+))?(?:\+[0-9A-Za-z-.]+)?$/;
+
+export const parseVersion = (raw: string): SemanticVersion | null => {
+  const groups = raw.trim().match(versionPattern)?.groups;
+  if (groups === undefined) {
+    return null;
+  }
+
+  const [major, minor, patch] = [groups["major"], groups["minor"], groups["patch"]].map((value) =>
+    Number.parseInt(value ?? "", 10),
+  );
+
+  if (major === undefined || minor === undefined || patch === undefined) {
+    return null;
+  }
+
+  if ([major, minor, patch].some((value) => Number.isNaN(value))) {
+    return null;
+  }
+
+  return { major, minor, patch, prerelease: groups["prerelease"] ?? null };
+};
+
+const compareNumbers = (a: number, b: number): number => (a === b ? 0 : a < b ? -1 : 1);
+
+const compareRelease = (a: SemanticVersion, b: SemanticVersion): number =>
+  compareNumbers(a.major, b.major) ||
+  compareNumbers(a.minor, b.minor) ||
+  compareNumbers(a.patch, b.patch);
+
+/**
+ * Orders `beta.9` before `beta.10`, the way semver does and the way a plain
+ * string comparison does not: numeric identifiers compare as numbers, and a
+ * numeric identifier always sorts below an alphanumeric one.
+ */
+const comparePrerelease = (a: string, b: string): number => {
+  const left = a.split(".");
+  const right = b.split(".");
+
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const one = left[index];
+    const other = right[index];
+
+    // A prerelease with fewer identifiers sorts first: beta < beta.1.
+    if (one === undefined) {
+      return -1;
+    }
+    if (other === undefined) {
+      return 1;
+    }
+    if (one === other) {
+      continue;
+    }
+
+    const oneNumber = /^\d+$/.test(one) ? Number.parseInt(one, 10) : null;
+    const otherNumber = /^\d+$/.test(other) ? Number.parseInt(other, 10) : null;
+
+    if (oneNumber !== null && otherNumber !== null) {
+      return compareNumbers(oneNumber, otherNumber);
+    }
+    if (oneNumber !== null) {
+      return -1;
+    }
+    if (otherNumber !== null) {
+      return 1;
+    }
+
+    return one < other ? -1 : 1;
+  }
+
+  return 0;
+};
+
+const compareVersions = (a: SemanticVersion, b: SemanticVersion): number => {
+  const release = compareRelease(a, b);
+  if (release !== 0) {
+    return release;
+  }
+
+  if (a.prerelease === b.prerelease) {
+    return 0;
+  }
+
+  // 0.4.0 beats 0.4.0-beta.1: a release is the finished form of its prereleases.
+  if (a.prerelease === null) {
+    return 1;
+  }
+  if (b.prerelease === null) {
+    return -1;
+  }
+
+  return comparePrerelease(a.prerelease, b.prerelease);
+};
+
+/**
+ * Whether `candidate` is worth moving to from `current`.
+ *
+ * A prerelease is only ever offered to somebody already running one. Lantern's
+ * betas share the `latest` dist-tag with its releases, so without this rule one
+ * beta would offer itself to every user on the next launch.
+ *
+ * A version that cannot be read is not an upgrade: silence beats a wrong nudge.
+ */
+export const isUpgrade = (current: string, candidate: string): boolean => {
+  const from = parseVersion(current);
+  const to = parseVersion(candidate);
+
+  if (from === null || to === null) {
+    return false;
+  }
+
+  if (to.prerelease !== null && from.prerelease === null) {
+    return false;
+  }
+
+  return compareVersions(to, from) > 0;
+};

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import packageJson from "../../package.json" with { type: "json" };
 import { maybeRunFirstRunWizard } from "../cli/firstRunWizard.ts";
 import { registerCliCommands } from "../cli/index.ts";
+import { maybeNotifyUpdate } from "../cli/update/notifyUpdate.ts";
 import type { CliOptions } from "./core/platform/services/LanternOptionsService.ts";
 import { checkNodeVersion } from "./nodeVersionCheck.ts";
 import { startServer } from "./startServer.ts";
@@ -43,6 +44,21 @@ program
 registerCliCommands(program);
 
 const main = async () => {
+  // Before the command runs, so the line lands in the scrollback rather than
+  // inside the alternate screen `browse` is about to take. It reads a cached
+  // answer and never waits on the network — the request that refreshes that
+  // cache is left running behind whatever starts next.
+  await maybeNotifyUpdate(
+    process.argv,
+    // stderr, because that is where the notice goes: `lantern | tee` is still
+    // somebody sitting at a terminal, and a redirected stdout is not a reason
+    // to keep quiet about a new version.
+    process.stderr.isTTY === true,
+    // oxlint-disable-next-line no-process-env
+    process.env,
+    Date.now(),
+  );
+
   await program.parseAsync(process.argv);
 };
 


### PR DESCRIPTION
Adds `lantern upgrade`, a version notice, and fixes two builds that were already broken on `main`.

This is release **N** of a two-step change: the second PR (#70) retires the `.deb`, `.rpm` and AUR channels. It has to land *after* this one ships, because somebody running a `.deb` only ever runs code that came in the `.deb` — the retirement message has to reach them in a release that still builds packages.

## `lantern upgrade`

Works out how Lantern was installed and acts accordingly:

| Install | What happens |
| --- | --- |
| npm / pnpm / yarn / bun global | Runs that manager's own install command |
| Homebrew | Refuses, prints `brew update && brew upgrade lantern-viewer` |
| Container | Refuses, prints `docker pull …` |
| `.deb` / `.rpm` (`/usr/lib/lantern`) | Refuses, and says how to move to npm |
| One-off `npx` | Refuses, explains npx already fetched the latest |
| git checkout | Refuses, prints `git pull && pnpm install && pnpm build` |
| Global prefix this user cannot write | Refuses, prints the `sudo …` form |

It never runs `sudo`, and never re-executes itself after an upgrade — the process that ran it is deliberately the last thing the old build does. `--check` and `--dry-run` change nothing.

The verbs differ per manager (`pnpm add -g`, not `pnpm install -g`; yarn 2 dropped `yarn global`), so they are spelled out and asserted in tests rather than templated.

## Update notice

One line at startup when the installed version is behind the published one. Read from a cache the previous check wrote, so it never delays a launch; the registry is asked at most once a day, in the background, and the answer shows up next time.

Silent where the answer is not actionable: no terminal attached, CI, Docker, `.deb`/`.rpm`, git checkout, `npx`. `NO_UPDATE_NOTIFIER`, `LANTERN_NO_UPDATE_NOTIFIER` or `"updateNotifier": false` in `~/.lantern/config.json` stop both the line and the request.

Prereleases now publish to the `next` dist-tag rather than `latest`, and a prerelease is only ever offered to somebody already running one — without that, a single beta would move every stable install onto it.

## Two builds that were already broken

Found while testing, reproduced on a pristine clone of `main`, so neither is caused by this branch:

- **The container image did not build.** `pnpm build` re-ran `pnpm install` (the install above it used `--ignore-scripts`, which pnpm reads back as an unfinished tree), which ran the root `prepare` hook — `lefthook install` — which needs a git repository, and `.git` is dockerignored. Fixed by turning that verification off for the build step.
- **The CLI harness image did not build.** goose's installer now rejects anything that is not semver, and the harness asked it for `stable`. Pinned to `v1.45.0`, the version `docker/compatibility.md` records as verified.

## Verification

Exercised against real installs rather than only unit tests: a global npm install in a container really upgraded 0.1.0 → 0.3.0 from the registry; the refusals were confirmed for the `/usr/lib/lantern` layout, a non-writable prefix, the npx cache, a git checkout and the image itself; the notice was confirmed on a pty and silent under `NO_UPDATE_NOTIFIER`, `CI` and no-TTY; `lantern --version` still returns in under half a second with no hanging socket.

Release image and harness image both build and serve. 1688 tests pass, `pnpm gatecheck check` and `scripts/lingui-check.sh` clean.

Windows self-replacement (`npm i -g` over a running install) is unverified — CI is Linux-only. It attempts it and prints an ENOTEMPTY/EPERM remediation block on failure.