### PR TITLE
docs: name the release the packages actually stopped at

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ in-app terminal is unavailable — see [Platform support](#platform-support).
 
 #### Coming from the `.deb` or `.rpm`?
 
-Those packages were retired after v0.4.0, and no newer version is published as one. They were meant
+Those packages were retired after v0.3.0, and no newer version is published as one. They were meant
 to save you installing Node by hand and did the opposite: `apt` enforces the `nodejs (>= 24)`
 dependency that no current release can satisfy, so the install failed outright.
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -89,8 +89,8 @@ change here is a change there.
 
 ## Retired channels
 
-The `.deb`, `.rpm` and AUR packages were dropped after v0.4.0, which is the last
-release that carries them. They existed to save users installing Node by hand,
+The `.deb`, `.rpm` and AUR packages were dropped after v0.3.0, the last release
+that carries them. They existed to save users installing Node by hand,
 and did the opposite: the packages declare `nodejs (>= 24)`, every current
 Debian and Ubuntu ships an older `nodejs`, and apt refuses the install outright
 rather than pulling a newer Node in. The deb and rpm trees were also not the npm
@@ -98,9 +98,15 @@ tree — `@anthropic-ai/claude-code` was stripped from them to stay under a size
 ceiling — so the three channels shipped materially different installs.
 
 `lantern upgrade` recognises the `/usr/lib/lantern` layout those packages used
-and tells whoever is still on one how to move to npm. That message is why v0.4.0
-had to ship the command _and_ the packages: somebody running a `.deb` only ever
-runs code that came in the `.deb`.
+and tells whoever is still on one how to move to npm — but it only exists from
+v0.4.0, and the packages stopped at v0.3.0, so nobody on one will ever read it:
+a `.deb` install runs only the code that came in the `.deb`.
+
+That ordering was meant to be the other way round, and it would have mattered if
+anyone were on one. Across v0.1.0 to v0.3.0 the deb and rpm assets were
+downloaded once in total, by a maintainer, and that install failed on the
+`nodejs (>= 24)` dependency — the failure that retired the channel. The README
+carries the move-to-npm instructions regardless, for anyone who turns up.
 
 What the packages did test, and still needs testing, is an install on a machine
 that has none of this repository's `node_modules`. `scripts/pack/smoke.sh` took


### PR DESCRIPTION
#70 landed before v0.4.0 was tagged, so the sequence it described did not happen: no release ships both the `.deb`/`.rpm` and the `lantern upgrade` message about them. v0.3.0 is the last release carrying packages, and v0.4.0 will be the first without them.

Corrects "retired after v0.4.0" to v0.3.0 in the README, and rewrites the note in `packaging/README.md` to say plainly that the in-tool message never reaches a package install — with why that turned out not to matter:

Across v0.1.0 to v0.3.0 the deb and rpm assets were downloaded **once** in total, and that install failed on `Depends: nodejs (>= 24) but 12.22.9~dfsg-1ubuntu3.6 is to be installed` — the failure that retired the channel in the first place.

The refusal text in `src/cli/upgrade/upgradePlan.ts` names no version, so it needs no change. The README's "Coming from the `.deb` or `.rpm`?" instructions stay for anyone who turns up with one.