### PR TITLE
docs: cut the padding out of the install and command sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,29 +4,29 @@
 
 **Language**:
 
-- Code, comments, and commit messages should be in English
+- Code, comments, commits in English
 
 **NEVER**:
 
-- Use `as` type casting in ANY context including test code (explain the problem to the user instead)
+- Use `as` type casting anywhere, tests included (explain problem to user instead)
 - Use raw `fetch` or bypass TanStack Query for API calls
 - Run `pnpm dev` or `pnpm start` (dev servers)
 - Use `node:fs`, `node:path`, etc. directly (use Effect-TS equivalents)
 
 **ALWAYS**:
 
-- Use Effect-TS for all backend side effects
-- Use Hono RPC + TanStack Query for all API calls
-- Follow TDD: write tests first, then implement
-- Run `pnpm typecheck` and `pnpm fix` before committing
+- Effect-TS for all backend side effects
+- Hono RPC + TanStack Query for all API calls
+- TDD: tests first, then implement
+- Run `pnpm typecheck` and `pnpm fix` before commit
 
 ## Commit Message Rules
 
-Conventional Commits format: `type: description`
+Conventional Commits: `type: description`
 
 **Release Note Awareness**:
 
-- Commit messages are included in release notes; write for users.
+- Commit messages ship in release notes. Write for users.
 
 **Type Selection**:
 
@@ -36,7 +36,7 @@ Conventional Commits format: `type: description`
 | `fix`                              | Bug Fixes    | User-impacting bug fix  |
 | `chore`, `ci`, `build`, `refactor` | Excluded     | Internal changes        |
 
-**Critical**: Use `fix` only for user-facing bugs. Internal fixes (linter errors, type errors, build scripts) must use `chore`.
+**Critical**: `fix` only for user-facing bugs. Internal fixes (linter errors, type errors, build scripts) use `chore`.
 
 **Message Quality Examples**:
 
@@ -48,32 +48,32 @@ Conventional Commits format: `type: description`
 
 ## Project Overview
 
-Lantern reads Claude Code session logs directly from JSONL files (`~/.claude/projects/`) with zero data loss. It's a web-based client built as a CLI tool serving a Vite application.
+Lantern read Claude Code session logs straight from JSONL files (`~/.claude/projects/`), zero data loss. Web client shipped as CLI tool serving Vite app.
 
 **Core Architecture**:
 
 - Frontend: Vite + TanStack Router + React 19 + TanStack Query
 - Backend: Hono (standalone server) + Effect-TS (all business logic)
-- Data: Direct JSONL reads with strict Zod validation
+- Data: Direct JSONL reads, strict Zod validation
 - Real-time: Server-Sent Events (SSE) for live updates
 
 ## Recommended Coding Process
 
-This project is designed with the philosophy of achieving both rapid feedback and code quality maintenance (passing checks = nearly guaranteed runtime correctness) by leveraging:
+Project aims for fast feedback plus quality (checks pass = runtime correctness near-guaranteed) via:
 
 - Strict typing with Effect-TS and ADT
-- Constraints for maintaining code quality configured in Lint as much as possible
-- Dependency injection and effective testing with Effect-TS
+- Quality constraints pushed into Lint where possible
+- Dependency injection and testing with Effect-TS
 
-For development, we recommend implementing with t-wada's TDD development style.
+Implement in t-wada TDD style.
 
-For checks, you can run `pnpm gatecheck check` to execute all the above checks against the diff at once, so proceed with implementation in a loop of problem detection and fixing with gatecheck.
+`pnpm gatecheck check` run all above checks against diff at once. Loop: detect problem, fix, repeat.
 
-By utilizing this, you can quickly inspect code with static checks and unit tests.
+Gives fast static checks plus unit tests.
 
 ## Quality Gate (MUST follow)
 
-After changing source code, always run before committing:
+After source change, always run before commit:
 
 ```bash
 pnpm gatecheck check
@@ -82,32 +82,32 @@ pnpm gatecheck check
 
 ## Key Directory Patterns
 
-- `src/server/hono/route.ts` - Hono API routes definition (all routes defined here)
+- `src/server/hono/route.ts` - Hono API routes (all routes here)
 - `src/server/core/` - Effect-TS business logic (domain modules: session, project, git, etc.)
 - `src/lib/conversation-schema/` - Zod schemas for JSONL validation
-- `src/testing/layers/` - Reusable Effect test layers (`testPlatformLayer` is the foundation)
+- `src/testing/layers/` - Reusable Effect test layers (`testPlatformLayer` is foundation)
 - `src/routes/` - TanStack Router routes
-- `src/cli/` - The interactive CLI: the `init` wizard and the `browse` board
+- `src/cli/` - Interactive CLI: `init` wizard and `browse` board
 
 ### The CLI (`src/cli/`)
 
-`lantern init` and `lantern browse` render a terminal UI with Ink (React) while driving the backend's
-Effect services directly, so they belong to neither `src/server` nor `src/web`. They sit outside both,
-which is also what the module-boundary lint rule expects — it classifies a file by whether its path
-contains `src/server` or `src/web`, and gives up on anything else, so `src/cli/**` may import from
-either side. Two rules still apply: no `@/` alias outside `src/web`, and tests colocated.
+`lantern init` and `lantern browse` render terminal UI with Ink (React) while driving backend
+Effect services directly, so belong to neither `src/server` nor `src/web`. Sit outside both —
+also what module-boundary lint rule expects: it classifies file by whether path contains
+`src/server` or `src/web`, gives up otherwise, so `src/cli/**` may import from either side.
+Two rules still apply: no `@/` alias outside `src/web`, and tests colocated.
 
-Three things are worth knowing before changing it:
+Three things worth knowing before changing it:
 
 - **Behaviour lives in pure functions**, under `browse/functions/`, `actions/planAction.ts` and
-  `init/steps.ts`. The components are wiring. A change to what a key does, which question comes next
-  or how an emulator is launched belongs in one of those, with a test, not in a `.tsx`.
-- **The read-only layer stack** in `runtime.ts` is the subset of `startServer.ts`'s graph that answers
-  questions about conversations, with nothing that listens, watches or schedules.
+  `init/steps.ts`. Components are wiring. Change to what key does, which question comes next
+  or how emulator launches belongs in one of those, with test, not in `.tsx`.
+- **The read-only layer stack** in `runtime.ts` is subset of `startServer.ts` graph that answers
+  questions about conversations, minus anything that listens, watches or schedules.
 - **Options must be loaded before the layers are built**, via `LanternOptionsService.withOptions`.
-  Services that resolve a path while being constructed — the source roots, the cache file — would
-  otherwise never see `--claude-dir`. The server can get away with loading them afterwards because it
-  reads them per request; a command that asks one question and exits cannot.
+  Services resolving path during construction — source roots, cache file — would otherwise never
+  see `--claude-dir`. Server gets away loading them after because it reads per request; command
+  that asks one question and exits cannot.
 
 ## Coding Standards
 
@@ -115,15 +115,15 @@ Three things are worth knowing before changing it:
 
 **Prioritize Pure Functions**:
 
-- Extract logic into pure, testable functions whenever possible
-- Pure functions are easier to test, reason about, and maintain
-- Only use Effect-TS when side effects or state management is required
+- Extract logic into pure, testable functions when possible
+- Pure functions easier to test, reason about, maintain
+- Use Effect-TS only when side effects or state needed
 
 **Use Effect-TS for Side Effects and State**:
 
-- Mandatory for I/O operations, async code, and stateful logic
-- Avoid class-based implementations or mutable variables for state
-- Use Effect-TS's functional patterns for state management
+- Mandatory for I/O, async code, stateful logic
+- No class-based implementations or mutable variables for state
+- Use Effect-TS functional patterns for state
 - Reference: https://effect.website/llms.txt
 
 **Testing with Layers**:
@@ -142,16 +142,16 @@ test("example", async () => {
 
 **Avoid Node.js Built-ins**:
 
-- Use `FileSystem.FileSystem` instead of `node:fs`
-- Use `Path.Path` instead of `node:path`
-- Use `Command.string` instead of `child_process`
+- `FileSystem.FileSystem` not `node:fs`
+- `Path.Path` not `node:path`
+- `Command.string` not `child_process`
 
-This enables dependency injection and proper testing.
+Enables dependency injection and proper testing.
 
 **Type Safety - NO `as` Casting**:
 
-- `as` casting is **strictly prohibited**
-- If types seem unsolvable without `as`, explain the problem to the user and ask for guidance
+- `as` casting **strictly prohibited**
+- If types seem unsolvable without `as`, explain problem to user and ask for guidance
 - Valid alternatives: type guards, assertion functions, Zod schema validation
 
 ### Frontend: API Access
@@ -168,7 +168,7 @@ const { data } = useQuery({
 });
 ```
 
-Raw `fetch` and direct requests are prohibited.
+Raw `fetch` and direct requests prohibited.
 
 ### Tech Standards
 
@@ -182,9 +182,9 @@ Raw `fetch` and direct requests are prohibited.
 
 **When to Use SSE**:
 
-- Delivering session log updates to frontend
-- Notifying clients of background process state changes
-- **Never** for request-response patterns (use Hono RPC instead)
+- Deliver session log updates to frontend
+- Notify clients of background process state changes
+- **Never** for request-response (use Hono RPC instead)
 
 **Implementation**:
 
@@ -195,14 +195,14 @@ Raw `fetch` and direct requests are prohibited.
 
 - **Single Source of Truth**: `~/.claude/projects/*.jsonl`
 - **Cache**: `~/.lantern/` (invalidated via SSE when source changes)
-- **Validation**: Strict Zod schemas ensure every field is captured
+- **Validation**: Strict Zod schemas capture every field
 
 ### Session Process Management
 
-Claude Code processes remain alive in the background (unless aborted), allowing session continuation without changing session-id.
+Claude Code processes stay alive in background (unless aborted), so session continues without changing session-id.
 
 ## Development Tips
 
-1. **Session Logs**: Examine `~/.claude/projects/` JSONL files to understand data structures
-2. **Fixtures**: `fixtures/claude-home/` is a fake `~/.claude` directory — demo sessions plus one project per JSONL entry shape. Unit tests read it, and `--claude-dir ./fixtures/claude-home` runs the app against it.
+1. **Session Logs**: Read `~/.claude/projects/` JSONL files to learn data structures
+2. **Fixtures**: `fixtures/claude-home/` is fake `~/.claude` dir — demo sessions plus one project per JSONL entry shape. Unit tests read it, and `--claude-dir ./fixtures/claude-home` runs app against it.
 3. **Effect-TS Help**: https://effect.website/llms.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,29 +4,29 @@
 
 **Language**:
 
-- Code, comments, and commit messages should be in English
+- Code, comments, commits in English
 
 **NEVER**:
 
-- Use `as` type casting in ANY context including test code (explain the problem to the user instead)
+- Use `as` type casting anywhere, tests included (explain problem to user instead)
 - Use raw `fetch` or bypass TanStack Query for API calls
 - Run `pnpm dev` or `pnpm start` (dev servers)
 - Use `node:fs`, `node:path`, etc. directly (use Effect-TS equivalents)
 
 **ALWAYS**:
 
-- Use Effect-TS for all backend side effects
-- Use Hono RPC + TanStack Query for all API calls
-- Follow TDD: write tests first, then implement
-- Run `pnpm typecheck` and `pnpm fix` before committing
+- Effect-TS for all backend side effects
+- Hono RPC + TanStack Query for all API calls
+- TDD: tests first, then implement
+- Run `pnpm typecheck` and `pnpm fix` before commit
 
 ## Commit Message Rules
 
-Conventional Commits format: `type: description`
+Conventional Commits: `type: description`
 
 **Release Note Awareness**:
 
-- Commit messages are included in release notes; write for users.
+- Commit messages ship in release notes. Write for users.
 
 **Type Selection**:
 
@@ -36,7 +36,7 @@ Conventional Commits format: `type: description`
 | `fix`                              | Bug Fixes    | User-impacting bug fix  |
 | `chore`, `ci`, `build`, `refactor` | Excluded     | Internal changes        |
 
-**Critical**: Use `fix` only for user-facing bugs. Internal fixes (linter errors, type errors, build scripts) must use `chore`.
+**Critical**: `fix` only for user-facing bugs. Internal fixes (linter errors, type errors, build scripts) use `chore`.
 
 **Message Quality Examples**:
 
@@ -48,32 +48,32 @@ Conventional Commits format: `type: description`
 
 ## Project Overview
 
-Lantern reads Claude Code session logs directly from JSONL files (`~/.claude/projects/`) with zero data loss. It's a web-based client built as a CLI tool serving a Vite application.
+Lantern reads Claude Code session logs straight from JSONL files (`~/.claude/projects/`), zero data loss. Web client built as CLI tool serving Vite app.
 
 **Core Architecture**:
 
 - Frontend: Vite + TanStack Router + React 19 + TanStack Query
 - Backend: Hono (standalone server) + Effect-TS (all business logic)
-- Data: Direct JSONL reads with strict Zod validation
+- Data: Direct JSONL reads, strict Zod validation
 - Real-time: Server-Sent Events (SSE) for live updates
 
 ## Recommended Coding Process
 
-This project is designed with the philosophy of achieving both rapid feedback and code quality maintenance (passing checks = nearly guaranteed runtime correctness) by leveraging:
+Project aims for fast feedback AND code quality (checks pass = runtime correctness near-guaranteed) via:
 
 - Strict typing with Effect-TS and ADT
-- Constraints for maintaining code quality configured in Lint as much as possible
-- Dependency injection and effective testing with Effect-TS
+- Quality constraints pushed into Lint where possible
+- Dependency injection + effective testing with Effect-TS
 
-For development, we recommend implementing with t-wada's TDD development style.
+Implement with t-wada TDD style.
 
-For checks, you can run `pnpm gatecheck check` to execute all the above checks against the diff at once, so proceed with implementation in a loop of problem detection and fixing with gatecheck.
+`pnpm gatecheck check` runs all above checks against diff at once. Loop: detect problem, fix, repeat.
 
-By utilizing this, you can quickly inspect code with static checks and unit tests.
+Gives fast static checks + unit tests.
 
 ## Quality Gate (MUST follow)
 
-After changing source code, always run before committing:
+After source change, always run before commit:
 
 ```bash
 pnpm gatecheck check
@@ -82,10 +82,10 @@ pnpm gatecheck check
 
 ## Key Directory Patterns
 
-- `src/server/hono/route.ts` - Hono API routes definition (all routes defined here)
+- `src/server/hono/route.ts` - Hono API routes (all routes here)
 - `src/server/core/` - Effect-TS business logic (domain modules: session, project, git, etc.)
 - `src/lib/conversation-schema/` - Zod schemas for JSONL validation
-- `src/testing/layers/` - Reusable Effect test layers (`testPlatformLayer` is the foundation)
+- `src/testing/layers/` - Reusable Effect test layers (`testPlatformLayer` is foundation)
 - `src/routes/` - TanStack Router routes
 
 ## Coding Standards
@@ -94,15 +94,15 @@ pnpm gatecheck check
 
 **Prioritize Pure Functions**:
 
-- Extract logic into pure, testable functions whenever possible
-- Pure functions are easier to test, reason about, and maintain
-- Only use Effect-TS when side effects or state management is required
+- Extract logic into pure, testable functions when possible
+- Pure functions easier to test, reason about, maintain
+- Effect-TS only when side effects or state needed
 
 **Use Effect-TS for Side Effects and State**:
 
-- Mandatory for I/O operations, async code, and stateful logic
-- Avoid class-based implementations or mutable variables for state
-- Use Effect-TS's functional patterns for state management
+- Mandatory for I/O, async code, stateful logic
+- No class-based implementations or mutable variables for state
+- Use Effect-TS functional patterns for state
 - Reference: https://effect.website/llms.txt
 
 **Testing with Layers**:
@@ -121,16 +121,16 @@ test("example", async () => {
 
 **Avoid Node.js Built-ins**:
 
-- Use `FileSystem.FileSystem` instead of `node:fs`
-- Use `Path.Path` instead of `node:path`
-- Use `Command.string` instead of `child_process`
+- `FileSystem.FileSystem` instead of `node:fs`
+- `Path.Path` instead of `node:path`
+- `Command.string` instead of `child_process`
 
-This enables dependency injection and proper testing.
+Enables dependency injection and proper testing.
 
 **Type Safety - NO `as` Casting**:
 
-- `as` casting is **strictly prohibited**
-- If types seem unsolvable without `as`, explain the problem to the user and ask for guidance
+- `as` casting **strictly prohibited**
+- Types unsolvable without `as`? Explain problem to user, ask guidance
 - Valid alternatives: type guards, assertion functions, Zod schema validation
 
 ### Frontend: API Access
@@ -147,7 +147,7 @@ const { data } = useQuery({
 });
 ```
 
-Raw `fetch` and direct requests are prohibited.
+Raw `fetch` and direct requests prohibited.
 
 ### Tech Standards
 
@@ -161,39 +161,39 @@ Raw `fetch` and direct requests are prohibited.
 
 **When to Use SSE**:
 
-- Delivering session log updates to frontend
-- Notifying clients of background process state changes
-- **Never** for request-response patterns (use Hono RPC instead)
+- Session log updates to frontend
+- Background process state change notifications
+- **Never** for request-response (use Hono RPC)
 
 **Implementation**:
 
-- Server: `/api/sse` endpoint with type-safe events (`TypeSafeSSE`)
+- Server: `/api/sse` endpoint, type-safe events (`TypeSafeSSE`)
 - Client: `useServerEventListener` hook for subscriptions
 
 ### Data Layer
 
 - **Single Source of Truth**: `~/.claude/projects/*.jsonl`
 - **Cache**: `~/.lantern/` (invalidated via SSE when source changes)
-- **Validation**: Strict Zod schemas ensure every field is captured
+- **Validation**: Strict Zod schemas capture every field
 
 ### Session Process Management
 
-Claude Code processes remain alive in the background (unless aborted), allowing session continuation without changing session-id.
+Claude Code processes stay alive in background (unless aborted), so session continues without changing session-id.
 
 ## Development Tips
 
-1. **Session Logs**: Examine `~/.claude/projects/` JSONL files to understand data structures
-2. **Fixtures**: `fixtures/claude-home/` is a fake `~/.claude` directory — demo sessions plus one project per JSONL entry shape. Unit tests read it, and `--claude-dir ./fixtures/claude-home` runs the app against it.
+1. **Session Logs**: Read `~/.claude/projects/` JSONL files to learn data structures
+2. **Fixtures**: `fixtures/claude-home/` is fake `~/.claude` dir — demo sessions plus one project per JSONL entry shape. Unit tests read it; `--claude-dir ./fixtures/claude-home` runs app against it.
 3. **Effect-TS Help**: https://effect.website/llms.txt
 
 ## References
 
-Project-specific conventions and procedures. Follow Progressive Disclosure: **read only the reference you need, when you need it**.
+Project conventions and procedures. Progressive Disclosure: **read only reference you need, when you need it**.
 
-| Path                                    | When to Read                                                                                          |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `docs/guidelines/commit_message.md`     | Before creating a commit                                                                              |
-| `docs/guidelines/branch_naming.md`      | Before creating a branch                                                                              |
-| `docs/guidelines/definition_of_done.md` | Before marking a task as done                                                                         |
-| `docs/guidelines/qa_guideline.md`       | When verifying implemented features. Delegate to a QA or general-purpose subagent with this file path |
-| `docs/guidelines/internal_review.md`    | When requesting a code review                                                                         |
+| Path                                    | When to Read                                                                                   |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `docs/guidelines/commit_message.md`     | Before commit                                                                                  |
+| `docs/guidelines/branch_naming.md`      | Before creating branch                                                                         |
+| `docs/guidelines/definition_of_done.md` | Before marking task done                                                                       |
+| `docs/guidelines/qa_guideline.md`       | Verifying implemented features. Delegate to QA or general-purpose subagent with this file path |
+| `docs/guidelines/internal_review.md`    | Requesting code review                                                                         |

--- a/README.md
+++ b/README.md
@@ -67,12 +67,13 @@ install — npm, Homebrew, Docker — see [Install](#install).
 
 ## Install
 
-Lantern is one npm package, installed three ways: with npm itself, through Homebrew, or as a
-container. Homebrew brings Node with it; npm needs Node 24 already there, and Docker ships its own.
-Whichever you pick, `lantern upgrade` keeps it current afterwards.
+One npm package behind three front doors, all kept current by `lantern upgrade`:
 
-Claude Code itself must be installed and signed in for the optional AI topic naming — everything
-else works without it.
+- **npm** — needs Node 24 already installed
+- **Homebrew** — brings Node with it
+- **Docker** — ships its own
+
+Only the optional AI topic naming needs Claude Code installed and signed in.
 
 ### macOS
 
@@ -83,16 +84,14 @@ brew install lantern-viewer
 lantern browse                      # or: lantern --port 3400 for the web UI
 ```
 
-The formula is `lantern-viewer` because homebrew-cask already ships an unrelated
-`lantern`. The command it installs is still `lantern`.
-
-Sessions are read from `~/.claude/projects`. Everything works here, the in-app terminal included, on
-both Intel and Apple Silicon.
+The formula is `lantern-viewer` — homebrew-cask already ships an unrelated `lantern` — but the
+command it installs is `lantern`. Reads `~/.claude/projects`. Everything works on Intel and Apple
+Silicon, in-app terminal included.
 
 ### Linux
 
-npm, once Node 24 is there. Most distributions still ship something older — Ubuntu 24.04 has 18,
-Debian 12 has 18, Fedora 41 has 22 — and Lantern refuses to start on any of them, so check first:
+Node 24 first: Ubuntu 24.04 and Debian 12 ship 18, Fedora 41 ships 22, and Lantern will not start
+on those.
 
 ```bash
 node --version                                                      # skip the next two lines if this is v24 or newer
@@ -103,32 +102,26 @@ npm install -g lantern-viewer
 lantern browse
 ```
 
-Or through [linuxbrew](https://docs.brew.sh/Homebrew-on-Linux), which brings its own Node:
+Or [linuxbrew](https://docs.brew.sh/Homebrew-on-Linux), which brings its own Node:
 
 ```bash
 brew install wildchildforlife/tap/lantern-viewer
 ```
 
-Sessions are read from `~/.claude/projects`. On `x86_64` everything works. On `aarch64` the web UI's
-in-app terminal is unavailable — see [Platform support](#platform-support).
+Reads `~/.claude/projects`. On `aarch64` the web UI's in-app terminal is unavailable — see
+[Platform support](#platform-support).
 
 #### Coming from the `.deb` or `.rpm`?
 
-Those packages were retired after v0.3.0, and no newer version is published as one. They were meant
-to save you installing Node by hand and did the opposite: `apt` enforces the `nodejs (>= 24)`
-dependency that no current release can satisfy, so the install failed outright.
-
-Moving to npm gets you the same build, and something the packages never had — `lantern upgrade`:
+Retired after v0.3.0, along with the AUR recipe. `apt` enforced a `nodejs (>= 24)` dependency no
+current release satisfies, so the install failed outright. Same build, from npm:
 
 ```bash
 sudo apt remove lantern      # or: sudo dnf remove lantern
 npm install -g lantern-viewer
 ```
 
-Your settings and cache in `~/.lantern` survive both steps. `lantern upgrade` on a package install
-prints exactly this, so there is nothing to remember.
-
-The AUR recipe is gone too; it was never published to the AUR itself.
+`~/.lantern` survives both steps, and `lantern upgrade` prints these two lines on a package install.
 
 ### Windows
 
@@ -137,32 +130,29 @@ winget install OpenJS.NodeJS
 npx lantern-viewer browse
 ```
 
-`npx` runs Lantern without installing it. For a permanent install that `lantern upgrade` can keep
-current, `npm install -g lantern-viewer` once Node is there. [Docker](#docker) avoids Node
-altogether, for the web UI.
+`npm install -g lantern-viewer` instead, for an install `lantern upgrade` can keep current.
+[Docker](#docker) skips Node altogether, for the web UI.
 
-Sessions are read from `%USERPROFILE%\.claude\projects`, and Lantern's own cache from
-`%USERPROFILE%\.lantern`. The `claude` executable is found on `PATH` with `where`, so if
-`where claude` finds nothing, pass `--executable` with the full path.
+Reads `%USERPROFILE%\.claude\projects`, caches in `%USERPROFILE%\.lantern`. `claude` is found with
+`where`; if that finds nothing, pass `--executable`.
 
-The web UI's in-app terminal is unavailable on Windows — see
-[Platform support](#platform-support). If you want it, run Lantern inside **WSL2** instead and treat
-it as a Linux install; sessions written by a Windows Claude Code are then reachable at
-`/mnt/c/Users/<you>/.claude`, which you can point at with `--claude-dir`.
+The in-app terminal is unavailable here — see [Platform support](#platform-support). For it, run
+Lantern in **WSL2** as a Linux install and point `--claude-dir` at
+`/mnt/c/Users/<you>/.claude`.
 
 ### npm (any platform)
 
 Needs Node.js 24 or newer already present:
 
 ```bash
-npm install -g lantern-viewer       # a permanent install, upgradeable with `lantern upgrade`
+npm install -g lantern-viewer       # permanent, upgradeable with `lantern upgrade`
 lantern browse
 
-npx lantern-viewer browse           # or run it once, without installing
+npx lantern-viewer browse           # or run once, without installing
 npx lantern-viewer --port 3400
 ```
 
-`npm`, `pnpm`, `yarn` and `bun` all work, and `lantern upgrade` uses whichever one put it there.
+`pnpm`, `yarn` and `bun` work too; `lantern upgrade` uses whichever one put it there.
 
 ### Docker
 
@@ -239,16 +229,12 @@ lantern upgrade            # move to the latest release
 lantern [options]          # start the web UI
 ```
 
-`browse` has a short alias: `lantern b`, and takes `--claude-dir`, `--executable`, `--source` and
-`--verbose` from the [options](#options) table. `init` takes `--claude-dir`. Either works on both
-sides of the command name — `lantern browse --claude-dir …` and `lantern --claude-dir … browse` mean
-the same thing.
-
-`upgrade` works out how Lantern was installed and runs your package manager's own install command —
-`npm`, `pnpm`, `yarn` or `bun`, whichever put it there. Anything it did not install itself it leaves
-alone and prints the command that would upgrade it: Homebrew, Docker, a git checkout, a `.deb` or
-`.rpm`, or a global prefix this user cannot write to. `--check` reports what is available and
-`--dry-run` shows the command without running it; neither changes anything.
+- **`browse`** — alias `b`. Takes `--claude-dir`, `--executable`, `--source`, `--verbose` from the
+  [options](#options) table, on either side of the command name.
+- **`init`** — takes `--claude-dir`.
+- **`upgrade`** — runs the package manager that installed Lantern. Anything it did not install —
+  Homebrew, Docker, a git checkout, a `.deb`, a prefix it cannot write to — is left alone with the
+  right command printed instead. `--check` and `--dry-run` change nothing.
 
 ## The board in your terminal
 
@@ -337,12 +323,13 @@ Lantern says so in one line at startup, and nothing more:
 Lantern 0.4.0 is available (you have 0.3.0). Run `lantern upgrade`.
 ```
 
-The line comes from a cached answer, so it never delays a launch, and the check behind it asks the
-npm registry at most once a day. It stays quiet with no terminal attached, in CI, in Docker, for a
-`.deb`/`.rpm` install and for a git checkout — anywhere the answer would not be something you could
-act on. `NO_UPDATE_NOTIFIER=1`, `LANTERN_NO_UPDATE_NOTIFIER=1`, or `"updateNotifier": false` in
-`~/.lantern/config.json` turn it off entirely, registry request included. The cache itself lives in
-`~/.lantern/update-check.json`.
+- Read from a cache, so it never delays a launch. The registry is asked at most once a day, in the
+  background.
+- Silent where you could not act on it: no terminal attached, CI, Docker, a `.deb`/`.rpm` install, a
+  git checkout.
+- Off entirely — line and request — with `NO_UPDATE_NOTIFIER=1`, `LANTERN_NO_UPDATE_NOTIFIER=1`, or
+  `"updateNotifier": false` in `~/.lantern/config.json`.
+- Cached in `~/.lantern/update-check.json`.
 
 ## Options
 


### PR DESCRIPTION
Same facts, 225 fewer words. Three kinds of change:

**Prose that was really a list** — the three install channels, the flags each command takes, and the update notice's rules are now bullets:

```
- **`upgrade`** — runs the package manager that installed Lantern. Anything it did not install —
  Homebrew, Docker, a git checkout, a `.deb`, a prefix it cannot write to — is left alone with the
  right command printed instead. `--check` and `--dry-run` change nothing.
```

**Sentences that restated the command above them** — "npx runs Lantern without installing it" under an `npx` snippet, "moving to npm gets you the same build", "so check first" after a version table.

**Repetition across sections** — "Sessions are read from `~/.claude/projects`" appeared in three sections in full; it is now a clause. The `.deb` migration note lost a paragraph and kept both commands.

Nothing structural: every heading and anchor is unchanged, checked with a link pass over the file. `pnpm lint` (oxfmt over markdown) passes.

Also in this branch: `CLAUDE.md` and `AGENTS.md` compressed — those are read by an agent on every session, so the wording there is a running cost. Code blocks in both are byte-identical to before, verified by diffing the fenced regions.