### PR TITLE
fix: print the command name Lantern did not recognise

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ when a terminal is the wrong shape for what you are doing. See [The web UI](#the
 ## Contents
 
 - [Quick start](#quick-start)
-- [Install](#install) · [macOS](#macos) · [Linux](#linux) · [Windows](#windows) ·
-  [npm](#npm-any-platform) · [Docker](#docker) · [From source](#from-source) ·
+- [Install](#install) · [npm](#npm-any-platform) · [macOS](#macos) · [Linux](#linux) ·
+  [Windows](#windows) · [Docker](#docker) · [From source](#from-source) ·
   [Platform support](#platform-support)
 - [Commands](#commands)
 - [The board in your terminal](#the-board-in-your-terminal) · [Setup](#setup) · [Options](#options)
@@ -73,7 +73,22 @@ One npm package behind three front doors, all kept current by `lantern upgrade`:
 - **Homebrew** — brings Node with it
 - **Docker** — ships its own
 
-Only the optional AI topic naming needs Claude Code installed and signed in.
+Only the optional AI topic naming needs Claude Code installed and signed in. There is no setup step
+to run afterwards — `lantern browse` works straight out of the box.
+
+### npm (any platform)
+
+Needs Node.js 24 or newer already present:
+
+```bash
+npm install -g lantern-viewer       # permanent, upgradeable with `lantern upgrade`
+lantern browse
+
+npx lantern-viewer browse           # or run once, without installing
+npx lantern-viewer --port 3400
+```
+
+`pnpm`, `yarn` and `bun` work too; `lantern upgrade` uses whichever one put it there.
 
 ### macOS
 
@@ -139,20 +154,6 @@ Reads `%USERPROFILE%\.claude\projects`, caches in `%USERPROFILE%\.lantern`. `cla
 The in-app terminal is unavailable here — see [Platform support](#platform-support). For it, run
 Lantern in **WSL2** as a Linux install and point `--claude-dir` at
 `/mnt/c/Users/<you>/.claude`.
-
-### npm (any platform)
-
-Needs Node.js 24 or newer already present:
-
-```bash
-npm install -g lantern-viewer       # permanent, upgradeable with `lantern upgrade`
-lantern browse
-
-npx lantern-viewer browse           # or run once, without installing
-npx lantern-viewer --port 3400
-```
-
-`pnpm`, `yarn` and `bun` work too; `lantern upgrade` uses whichever one put it there.
 
 ### Docker
 
@@ -224,14 +225,16 @@ from either are welcome.
 
 ```bash
 lantern browse             # the board, in your terminal
-lantern init               # set Lantern up, and remember the answers
+lantern init               # optional: set Lantern up, and remember the answers
 lantern upgrade            # move to the latest release
 lantern [options]          # start the web UI
 ```
 
 - **`browse`** — alias `b`. Takes `--claude-dir`, `--executable`, `--source`, `--verbose` from the
   [options](#options) table, on either side of the command name.
-- **`init`** — takes `--claude-dir`.
+- **`init`** — takes `--claude-dir`. Never required: every setting it writes has a working default,
+  and `browse` never stops to ask for one. Run it when you want a different port, bind address or
+  set of agent CLIs remembered.
 - **`upgrade`** — runs the package manager that installed Lantern. Anything it did not install —
   Homebrew, Docker, a git checkout, a `.deb`, a prefix it cannot write to — is left alone with the
   right command printed instead. `--check` and `--dry-run` change nothing.
@@ -299,13 +302,17 @@ right; the keys are unchanged.
 
 ## Setup
 
-The first time you run `lantern` at a terminal it walks you through setup: which agent CLIs to read,
-where they keep their logs, which port and address to bind, and whether to enable the in-app
-terminal. Every question arrives with the answer already detected, so the fast path is Enter a few
-times.
+Setup is optional. Everything Lantern needs has a default, so `lantern browse` goes straight to the
+board on a fresh machine and never stops to ask a question.
+
+What the offer covers is the web UI, which has more to decide: the first time you run `lantern` with
+no command at a terminal it walks you through which agent CLIs to read, where they keep their logs,
+which port and address to bind, and whether to enable the in-app terminal. Every question arrives
+with the answer already detected, so the fast path is Enter a few times.
 
 The answers go in `~/.lantern/config.json` (and the CLI selection in `~/.lantern/sources/sources.json`,
-the same file the settings panel writes). Run `lantern init` again at any point to change them.
+the same file the settings panel writes). Run `lantern init` at any point to change them — or to
+answer the questions up front, before ever starting the server.
 
 Settings sit **below** environment variables in the [options](#options) table: a flag beats an
 environment variable, which beats the file, which beats the built-in default. So a container's `PORT`

--- a/src/cli/unknownCommand.test.ts
+++ b/src/cli/unknownCommand.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { describeUnknownCommand, type KnownCommand, nearestCommand } from "./unknownCommand.ts";
+
+const known: KnownCommand[] = [
+  { name: "browse", aliases: ["b"] },
+  { name: "init", aliases: [] },
+  { name: "upgrade", aliases: [] },
+];
+
+describe("nearestCommand", () => {
+  it("finds the command behind a typo", () => {
+    expect(nearestCommand("brows", known)).toBe("browse");
+    expect(nearestCommand("borwse", known)).toBe("browse");
+    expect(nearestCommand("upgade", known)).toBe("upgrade");
+    expect(nearestCommand("iniit", known)).toBe("init");
+  });
+
+  it("looks past case", () => {
+    expect(nearestCommand("Browse", known)).toBe("browse");
+  });
+
+  /**
+   * An alias is a real way to spell the command, so a typo of one is a typo of
+   * the command — but what comes back is the name, which is the half of the
+   * pair worth printing.
+   */
+  it("matches aliases, and answers with the command's own name", () => {
+    expect(nearestCommand("boad", [{ name: "browse", aliases: ["board"] }])).toBe("browse");
+  });
+
+  it("suggests nothing for a word that resembles no command", () => {
+    expect(nearestCommand("sessions", known)).toBe(null);
+    expect(nearestCommand("serve", known)).toBe(null);
+  });
+
+  /**
+   * `lantern x` is a mistake with no obvious intent behind it. Every one-letter
+   * word is a single edit from the `b` alias, so guessing here would answer
+   * almost anything with "did you mean browse?".
+   */
+  it("does not guess from one or two letters", () => {
+    expect(nearestCommand("x", known)).toBe(null);
+    expect(nearestCommand("br", known)).toBe(null);
+  });
+});
+
+describe("describeUnknownCommand", () => {
+  /**
+   * The one call site asks this question of every launch, including the plain
+   * `lantern` that starts the web UI. Nothing typed, nothing to complain about.
+   */
+  it("has nothing to say when no command was typed", () => {
+    expect(describeUnknownCommand([], known, "lantern")).toBe(null);
+  });
+
+  it("names what was typed, and what it probably meant", () => {
+    const message = describeUnknownCommand(["brows"], known, "lantern");
+
+    expect(message).toContain("unknown command 'brows'");
+    expect(message).toContain("`lantern browse`");
+  });
+
+  it("still lists the commands when it has nothing to suggest", () => {
+    const message = describeUnknownCommand(["sessions"], known, "lantern");
+
+    expect(message).toContain("unknown command 'sessions'");
+    expect(message).not.toContain("Did you mean");
+    expect(message).toContain("browse, init, upgrade");
+  });
+
+  it("says how to start the web UI, which is the command that is not one", () => {
+    const message = describeUnknownCommand(["sessions"], known, "lantern");
+
+    expect(message).toContain("`lantern` on its own");
+    expect(message).toContain("`lantern --help`");
+  });
+
+  /** Only the first word is the command; the rest were meant as its arguments. */
+  it("reports the first word alone when several follow", () => {
+    const message = describeUnknownCommand(["brows", "orders-api"], known, "lantern");
+
+    expect(message).toContain("unknown command 'brows'");
+    expect(message).not.toContain("orders-api");
+  });
+
+  it("uses the name the program was invoked under", () => {
+    expect(describeUnknownCommand(["brows"], known, "lantern-viewer")).toContain(
+      "`lantern-viewer browse`",
+    );
+  });
+});

--- a/src/cli/unknownCommand.ts
+++ b/src/cli/unknownCommand.ts
@@ -1,0 +1,112 @@
+/** A command the program answers to, under its own name or an alias. */
+export type KnownCommand = {
+  name: string;
+  aliases: readonly string[];
+};
+
+/**
+ * How many single-character edits turn one word into the other.
+ *
+ * The usual two-row Levenshtein: only the previous row is ever read, so the
+ * table never has to exist.
+ */
+const editDistance = (a: string, b: string): number => {
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+
+  for (let row = 1; row <= a.length; row += 1) {
+    const current = [row];
+
+    for (let column = 1; column <= b.length; column += 1) {
+      const swapped = a[row - 1] === b[column - 1] ? 0 : 1;
+
+      current.push(
+        Math.min(
+          (previous[column - 1] ?? 0) + swapped,
+          (current[column - 1] ?? 0) + 1,
+          (previous[column] ?? 0) + 1,
+        ),
+      );
+    }
+
+    previous = current;
+  }
+
+  return previous[b.length] ?? 0;
+};
+
+/** Below this, a word is too short for a typo to be told from a different word. */
+const shortestGuessable = 3;
+
+/** Edits allowed between what was typed and the command it is taken to mean. */
+const allowedEdits = 2;
+
+/**
+ * The command a mistyped word was probably meant to be, or `null`.
+ *
+ * Aliases are matched as well as names — they are how the command is spelled,
+ * so a typo of one is still a typo of the command — but what comes back is
+ * always the full name, because that is the useful thing to print.
+ */
+export const nearestCommand = (typed: string, known: readonly KnownCommand[]): string | null => {
+  if (typed.length < shortestGuessable) {
+    return null;
+  }
+
+  const word = typed.toLowerCase();
+
+  const ranked = known
+    .flatMap((command) =>
+      [command.name, ...command.aliases].map((spelling) => ({
+        name: command.name,
+        distance: editDistance(word, spelling.toLowerCase()),
+      })),
+    )
+    .filter((candidate) => candidate.distance <= allowedEdits)
+    // Name second, so that two equally close commands always resolve the same
+    // way rather than by whichever was registered first.
+    .sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name));
+
+  return ranked[0]?.name ?? null;
+};
+
+/**
+ * What to print when the arguments name no command Lantern has.
+ *
+ * Commander's own answer is "too many arguments. Expected 0 arguments but got
+ * 1", because a plain `lantern` starts the web UI and so the root command has
+ * an action of its own: a mistyped subcommand arrives as one argument too many
+ * rather than as an unknown command. That message describes the parser's
+ * problem rather than the reader's, and never mentions the word it choked on.
+ *
+ * Returns `null` when there is nothing to complain about, which is every launch
+ * that meant to start the server.
+ */
+export const describeUnknownCommand = (
+  given: readonly string[],
+  known: readonly KnownCommand[],
+  programName: string,
+): string | null => {
+  const typed = given[0];
+
+  if (typed === undefined) {
+    return null;
+  }
+
+  // Only the first word is being read as a command. Anything after it was meant
+  // as an argument to whatever that word was supposed to be, so repeating it
+  // back would only bury the part that is wrong.
+  const suggestion = nearestCommand(typed, known);
+  const names = known.map((command) => command.name).join(", ");
+
+  const opening =
+    suggestion === null
+      ? `error: unknown command '${typed}'`
+      : `error: unknown command '${typed}'. Did you mean \`${programName} ${suggestion}\`?`;
+
+  return [
+    opening,
+    "",
+    `Commands: ${names}. \`${programName}\` on its own starts the web UI, and`,
+    `\`${programName} --help\` lists the options.`,
+  ].join("\n");
+};

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import packageJson from "../../package.json" with { type: "json" };
 import { maybeRunFirstRunWizard } from "../cli/firstRunWizard.ts";
 import { registerCliCommands } from "../cli/index.ts";
+import { describeUnknownCommand } from "../cli/unknownCommand.ts";
 import { maybeNotifyUpdate } from "../cli/update/notifyUpdate.ts";
 import type { CliOptions } from "./core/platform/services/LanternOptionsService.ts";
 import { checkNodeVersion } from "./nodeVersionCheck.ts";
@@ -12,7 +13,12 @@ checkNodeVersion();
 
 const program = new Command();
 
-program.name(packageJson.name).version(packageJson.version).description(packageJson.description);
+// The npm package is `lantern-viewer`, because homebrew-cask already ships an
+// unrelated `lantern` — but the command it installs is `lantern`, and that is
+// what help text and error messages have to print for them to be paste-able.
+const [commandName = packageJson.name] = Object.keys(packageJson.bin);
+
+program.name(commandName).version(packageJson.version).description(packageJson.description);
 
 // start server
 program
@@ -32,7 +38,23 @@ program
     "agent CLI to read sessions from; repeat for more than one",
     (value: string, previous: string[] | undefined) => [...(previous ?? []), value],
   )
-  .action(async (options: CliOptions & { init?: boolean }) => {
+  // Commander would otherwise reject a mistyped subcommand as one argument too
+  // many, in those words. Taking the arguments instead lets the action say
+  // which word it did not know — see `describeUnknownCommand`.
+  .allowExcessArguments()
+  .action(async (options: CliOptions & { init?: boolean }, command: Command) => {
+    const unknown = describeUnknownCommand(
+      command.args,
+      command.commands.map((sub) => ({ name: sub.name(), aliases: sub.aliases() })),
+      command.name(),
+    );
+
+    if (unknown !== null) {
+      process.stderr.write(`${unknown}\n`);
+      process.exitCode = 1;
+      return;
+    }
+
     // A first launch at a terminal walks through setup, then carries straight
     // on into starting the server with the answers. Anything without a
     // terminal — a container, CI, a pipe — skips it silently.


### PR DESCRIPTION
Two changes to how Lantern introduces itself on the command line.

## 1. Unknown subcommands say what was wrong

`lantern brows` answered:

```
error: too many arguments. Expected 0 arguments but got 1.
```

That is the parser's problem, not the reader's, and it never names the word it choked on. The cause: a plain `lantern` starts the web UI, so the root command carries an action of its own — a mistyped subcommand arrives as one argument too many rather than as an unknown command, and commander's unknown-command path is never reached.

Now:

```
error: unknown command 'brows'. Did you mean `lantern browse`?

Commands: init, browse, upgrade. `lantern` on its own starts the web UI, and
`lantern --help` lists the options.
```

- Suggests the command within two edits of what was typed (`describeUnknownCommand` / `nearestCommand` in `src/cli/unknownCommand.ts`, both pure and unit-tested).
- Aliases count as spellings, so a typo of `b` still resolves to `browse` — and the *name* is what gets printed, not the alias.
- Words under three letters suggest nothing, because every one-letter word is a single edit from the `b` alias and guessing there would answer almost anything with "did you mean browse?".
- Exits 1, on stderr.

Real subcommands, options, `--help` and the server path are unaffected — verified by hand on Node 24.

Also fixed: help text and these messages print `lantern`, read from the package's `bin` entry, instead of the package name `lantern-viewer`. A suggestion has to be paste-able, and `lantern-viewer browse` is not a command anybody has. `packageJson.name` is untouched everywhere it means the npm package (registry lookup, upgrade plan).

Not covered: excess arguments *after* a real subcommand (`lantern browse orders-api`) still produce commander's stock "too many arguments" message. Same class of papercut, but out of scope here — happy to follow up.

## 2. README (unchanged from the first review round)

- `### npm (any platform)` moves to the top of **Install**, ahead of macOS/Linux/Windows, with the Contents list reordered to match.
- Says plainly that `lantern init` is optional. `maybeRunFirstRunWizard` is called from `src/server/main.ts` only — the plain `lantern` path; `browse` goes straight to `runBrowse(...)` with `loadStoredOptions()`, which falls back to defaults when `~/.lantern/config.json` is absent. So `browse` never prompts and never needs the wizard.