### PR TITLE
fix: turn away arguments a subcommand cannot use

### DIFF
--- a/src/cli/excessArguments.test.ts
+++ b/src/cli/excessArguments.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { describeExcessArguments } from "./excessArguments.ts";
+
+describe("describeExcessArguments", () => {
+  it("has nothing to say when the command was typed on its own", () => {
+    expect(describeExcessArguments([], "lantern browse")).toBe(null);
+  });
+
+  it("names the command and the word it cannot take", () => {
+    const message = describeExcessArguments(["orders-api"], "lantern browse");
+
+    expect(message).toContain("`lantern browse` takes no arguments");
+    expect(message).toContain("'orders-api'");
+  });
+
+  it("names every stray word, not only the first", () => {
+    const message = describeExcessArguments(["orders-api", "webhooks"], "lantern browse");
+
+    expect(message).toContain("'orders-api', 'webhooks'");
+  });
+
+  /**
+   * The reader's next move is finding out what the command does take, and each
+   * one has its own options.
+   */
+  it("points at the command's own help rather than the program's", () => {
+    const message = describeExcessArguments(["extra"], "lantern init");
+
+    expect(message).toContain("`lantern init --help`");
+  });
+});

--- a/src/cli/excessArguments.ts
+++ b/src/cli/excessArguments.ts
@@ -1,0 +1,27 @@
+/**
+ * What to print when a subcommand is handed words it has no use for.
+ *
+ * None of Lantern's subcommands take a positional argument — everything they
+ * read is a flag — so anything left over is a mistake worth naming rather than
+ * a value worth guessing at. `lantern browse orders-api` is somebody expecting
+ * to open one project; saying so beats browsing everything as though they had
+ * not asked.
+ *
+ * Returns `null` when there is nothing left over, which is every correct run.
+ */
+export const describeExcessArguments = (
+  given: readonly string[],
+  commandPath: string,
+): string | null => {
+  if (given.length === 0) {
+    return null;
+  }
+
+  const stray = given.map((word) => `'${word}'`).join(", ");
+
+  return [
+    `error: \`${commandPath}\` takes no arguments, but got ${stray}.`,
+    "",
+    `Run \`${commandPath} --help\` for the options it does take.`,
+  ].join("\n");
+};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,32 @@
 import type { Command } from "commander";
 import { parseSharedOptions } from "./commandOptions.ts";
 import { loadStoredOptions } from "./config/loadStoredOptions.ts";
+import { describeExcessArguments } from "./excessArguments.ts";
+
+/**
+ * Turns leftover words away before the command they were typed at does anything.
+ *
+ * Commander would otherwise decide this itself, and its answer depends on a
+ * setting it copies down from the root command — `copyInheritedSettings` carries
+ * `allowExcessArguments` to every subcommand registered after it. The root
+ * command has to allow them, because that is how a mistyped subcommand reaches
+ * an error message that names it, so each subcommand has to say what it makes
+ * of them rather than inherit an answer meant for somebody else.
+ *
+ * Returns whether the caller should stop.
+ */
+const rejectExcessArguments = (program: Command, command: Command): boolean => {
+  const problem = describeExcessArguments(command.args, `${program.name()} ${command.name()}`);
+
+  if (problem === null) {
+    return false;
+  }
+
+  process.stderr.write(`${problem}\n`);
+  process.exitCode = 1;
+
+  return true;
+};
 
 /**
  * Registers Lantern's interactive subcommands.
@@ -18,7 +44,12 @@ export const registerCliCommands = (program: Command): void => {
     .command("init")
     .description("set Lantern up interactively, and remember the answers")
     .option("--claude-dir <claude-dir>", "path to the claude directory to read")
+    .allowExcessArguments()
     .action(async (_options: unknown, command: Command) => {
+      if (rejectExcessArguments(program, command)) {
+        return;
+      }
+
       const { runInit } = await import("./init/initCommand.tsx");
       const config = await runInit(parseSharedOptions(command.optsWithGlobals()));
       process.exitCode = config === null ? 1 : 0;
@@ -36,7 +67,12 @@ export const registerCliCommands = (program: Command): void => {
       "agent CLI to read sessions from; repeat for more than one",
       (value: string, previous: string[] | undefined) => [...(previous ?? []), value],
     )
+    .allowExcessArguments()
     .action(async (_options: unknown, command: Command) => {
+      if (rejectExcessArguments(program, command)) {
+        return;
+      }
+
       const { runBrowse } = await import("./browse/browseCommand.tsx");
       const exitCode = await runBrowse(
         parseSharedOptions(command.optsWithGlobals()),
@@ -50,7 +86,12 @@ export const registerCliCommands = (program: Command): void => {
     .description("upgrade Lantern where it was installed, or say what would")
     .option("--check", "report what is available, without changing anything")
     .option("--dry-run", "print the command that would run, without running it")
+    .allowExcessArguments()
     .action(async (_options: unknown, command: Command) => {
+      if (rejectExcessArguments(program, command)) {
+        return;
+      }
+
       const { parseUpgradeOptions, runUpgrade } = await import("./upgrade/upgradeCommand.ts");
 
       // `opts()`, not `optsWithGlobals()`: these two flags belong to this


### PR DESCRIPTION
Follow-up to #79, and a regression it introduced.

## What was wrong

`lantern browse orders-api` browsed everything, as though the project name had not been typed. Same for `lantern init extra` and `lantern upgrade now` — the stray word was silently dropped.

Commander's `copyInheritedSettings` copies `_allowExcessArguments` from the root command to every subcommand registered after it (`node_modules/commander/lib/command.js:108`). #79 called `.allowExcessArguments()` on the root — necessary, because that is how a mistyped subcommand reaches an error message that names it — and `registerCliCommands(program)` runs afterwards, so `browse`, `init` and `upgrade` all inherited permission to ignore whatever they were handed.

Before #79 they produced commander's stock `error: too many arguments for 'browse'.` Silence is the worse of the two, so this is a regression, not just a wording nit.

## What it does now

None of the three take a positional argument — everything they read is a flag — so each says what it made of the leftovers rather than inheriting an answer meant for the root command:

```
error: `lantern browse` takes no arguments, but got 'orders-api'.

Run `lantern browse --help` for the options it does take.
```

- Exits 1, on stderr, before the command does any work.
- Names the command by its own name, so `lantern b orders-api` answers for `lantern browse`.
- Lists every stray word, not just the first.
- `.allowExcessArguments()` is now set explicitly on each subcommand, so the behaviour no longer depends on registration order relative to the root command.

`describeExcessArguments` is pure and unit-tested in `src/cli/excessArguments.ts`.

## Verified by hand on Node 24

| Command | Result |
| --- | --- |
| `lantern browse orders-api` | error, exit 1 |
| `lantern b orders-api` | error naming `lantern browse`, exit 1 |
| `lantern init extra` / `lantern upgrade now` | error, exit 1 |
| `lantern browse --claude-dir ./fixtures/claude-home` | runs |
| `lantern upgrade --check` | runs (exit 1 is its pre-existing answer for a git checkout) |
| `lantern brows` | still the #79 unknown-command message |