### PR TITLE
feat: say why sorting into topics stopped, not just how many were left

### DIFF
--- a/src/cli/browse/functions/classifyMessage.test.ts
+++ b/src/cli/browse/functions/classifyMessage.test.ts
@@ -27,9 +27,33 @@ describe("describeClassifyStatus", () => {
 
   it("reports a pass that gave up part way as a failure", () => {
     expect(
-      describeClassifyStatus({ kind: "stopped-early", classified: 40, remaining: 12 }),
+      describeClassifyStatus({
+        kind: "stopped-early",
+        classified: 40,
+        remaining: 12,
+        reason: null,
+      }),
     ).toStrictEqual({
       text: "Sorted 40, then stopped early. 12 still have no topic.",
+      tone: "error",
+    });
+  });
+
+  /**
+   * The count is not the problem, and the problem is what the user can act on:
+   * a CLI installed under another node version is invisible to the board
+   * otherwise, since the log it is written to is the screen the board draws on.
+   */
+  it("leads with why it stopped when the pass knows", () => {
+    expect(
+      describeClassifyStatus({
+        kind: "stopped-early",
+        classified: 0,
+        remaining: 22,
+        reason: "Claude Code CLI not found - pass --executable /path/to/claude",
+      }),
+    ).toStrictEqual({
+      text: "Claude Code CLI not found - pass --executable /path/to/claude. 22 still have no topic.",
       tone: "error",
     });
   });

--- a/src/cli/browse/functions/classifyMessage.ts
+++ b/src/cli/browse/functions/classifyMessage.ts
@@ -16,7 +16,12 @@ export const describeClassifyStatus = (outcome: ClassifyOutcome): Status => {
   switch (outcome.kind) {
     case "stopped-early":
       return {
-        text: `Sorted ${outcome.classified}, then stopped early. ${outcome.remaining} still have no topic.`,
+        // What went wrong first, when the pass knows: a count says a pass
+        // failed, and only the reason says what to do about it.
+        text:
+          outcome.reason === null
+            ? `Sorted ${outcome.classified}, then stopped early. ${outcome.remaining} still have no topic.`
+            : `${outcome.reason}. ${outcome.remaining} still have no topic.`,
         tone: "error",
       };
     case "nothing-to-do":

--- a/src/lib/i18n/locales/en/messages.json
+++ b/src/lib/i18n/locales/en/messages.json
@@ -5275,7 +5275,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        114
+        119
       ]
     ],
     "translation": "Classification failed"
@@ -5291,7 +5291,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        109
+        114
       ]
     ],
     "translation": "Classification failed ({status})"
@@ -5307,7 +5307,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        98
+        103
       ]
     ],
     "translation": "{count} were left for the next pass"
@@ -5319,7 +5319,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        62
+        67
       ]
     ],
     "translation": "Every conversation already has a topic"
@@ -5331,7 +5331,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        72
+        77
       ]
     ],
     "translation": "None of the selected conversations could be sorted"
@@ -5347,7 +5347,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        87
+        92
       ]
     ],
     "translation": "Sorted {count} conversations into topics"
@@ -5366,7 +5366,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        82
+        87
       ]
     ],
     "translation": "Sorted {count} conversations into topics ({cost} USD of usage)"

--- a/src/lib/i18n/locales/es/messages.json
+++ b/src/lib/i18n/locales/es/messages.json
@@ -5275,7 +5275,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        114
+        119
       ]
     ],
     "translation": "La clasificación falló"
@@ -5291,7 +5291,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        109
+        114
       ]
     ],
     "translation": "La clasificación falló ({status})"
@@ -5307,7 +5307,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        98
+        103
       ]
     ],
     "translation": "{count} quedaron para la próxima pasada"
@@ -5319,7 +5319,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        62
+        67
       ]
     ],
     "translation": "Todas las conversaciones ya tienen un tema"
@@ -5331,7 +5331,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        72
+        77
       ]
     ],
     "translation": "No se pudo clasificar ninguna de las conversaciones seleccionadas"
@@ -5347,7 +5347,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        87
+        92
       ]
     ],
     "translation": "Se clasificaron {count} conversaciones en temas"
@@ -5366,7 +5366,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        82
+        87
       ]
     ],
     "translation": "Se clasificaron {count} conversaciones en temas ({cost} USD de uso)"

--- a/src/lib/i18n/locales/fr/messages.json
+++ b/src/lib/i18n/locales/fr/messages.json
@@ -5275,7 +5275,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        114
+        119
       ]
     ],
     "translation": "La classification a échoué"
@@ -5291,7 +5291,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        109
+        114
       ]
     ],
     "translation": "La classification a échoué ({status})"
@@ -5307,7 +5307,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        98
+        103
       ]
     ],
     "translation": "{count} ont été gardées pour le prochain passage"
@@ -5319,7 +5319,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        62
+        67
       ]
     ],
     "translation": "Toutes les conversations ont déjà un sujet"
@@ -5331,7 +5331,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        72
+        77
       ]
     ],
     "translation": "Aucune des conversations sélectionnées n'a pu être classée"
@@ -5347,7 +5347,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        87
+        92
       ]
     ],
     "translation": "{count} conversations classées par sujet"
@@ -5366,7 +5366,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        82
+        87
       ]
     ],
     "translation": "{count} conversations classées par sujet ({cost} USD d'utilisation)"

--- a/src/lib/i18n/locales/ja/messages.json
+++ b/src/lib/i18n/locales/ja/messages.json
@@ -5275,7 +5275,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        114
+        119
       ]
     ],
     "translation": "分類に失敗しました"
@@ -5291,7 +5291,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        109
+        114
       ]
     ],
     "translation": "分類に失敗しました（{status}）"
@@ -5307,7 +5307,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        98
+        103
       ]
     ],
     "translation": "{count}件は次回の実行に回されました"
@@ -5319,7 +5319,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        62
+        67
       ]
     ],
     "translation": "すべての会話にトピックがあります"
@@ -5331,7 +5331,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        72
+        77
       ]
     ],
     "translation": "選択した会話はいずれも分類できませんでした"
@@ -5347,7 +5347,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        87
+        92
       ]
     ],
     "translation": "{count}件の会話をトピックに分類しました"
@@ -5366,7 +5366,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        82
+        87
       ]
     ],
     "translation": "{count}件の会話をトピックに分類しました（使用額 {cost} USD）"

--- a/src/lib/i18n/locales/pt/messages.json
+++ b/src/lib/i18n/locales/pt/messages.json
@@ -5275,7 +5275,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        114
+        119
       ]
     ],
     "translation": "A classificação falhou"
@@ -5291,7 +5291,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        109
+        114
       ]
     ],
     "translation": "A classificação falhou ({status})"
@@ -5307,7 +5307,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        98
+        103
       ]
     ],
     "translation": "{count} ficaram para a próxima passagem"
@@ -5319,7 +5319,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        62
+        67
       ]
     ],
     "translation": "Todas as conversas já têm um tópico"
@@ -5331,7 +5331,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        72
+        77
       ]
     ],
     "translation": "Nenhuma das conversas selecionadas pôde ser classificada"
@@ -5347,7 +5347,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        87
+        92
       ]
     ],
     "translation": "{count} conversas classificadas em tópicos"
@@ -5366,7 +5366,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        82
+        87
       ]
     ],
     "translation": "{count} conversas classificadas em tópicos ({cost} USD de uso)"

--- a/src/lib/i18n/locales/zh_CN/messages.json
+++ b/src/lib/i18n/locales/zh_CN/messages.json
@@ -5275,7 +5275,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        114
+        119
       ]
     ],
     "translation": "归类失败"
@@ -5291,7 +5291,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        109
+        114
       ]
     ],
     "translation": "归类失败（{status}）"
@@ -5307,7 +5307,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        98
+        103
       ]
     ],
     "translation": "有 {count} 条留到下次归类"
@@ -5319,7 +5319,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        62
+        67
       ]
     ],
     "translation": "所有会话都已有主题"
@@ -5331,7 +5331,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        72
+        77
       ]
     ],
     "translation": "所选会话均无法归类"
@@ -5347,7 +5347,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        87
+        92
       ]
     ],
     "translation": "已将 {count} 条会话归入主题"
@@ -5366,7 +5366,7 @@
     "origin": [
       [
         "src/web/lib/api/useClassifyTopics.ts",
-        82
+        87
       ]
     ],
     "translation": "已将 {count} 条会话归入主题（用量 {cost} 美元）"

--- a/src/lib/topics/classifyOutcome.test.ts
+++ b/src/lib/topics/classifyOutcome.test.ts
@@ -10,6 +10,7 @@ const result = (overrides: Partial<ClassifyResult> = {}): ClassifyResult => ({
   requested: 0,
   queued: 0,
   failed: false,
+  failureReason: null,
   ...overrides,
 });
 
@@ -19,7 +20,7 @@ test("a pass that gave up part way reports what is left", () => {
       result({ classified: 40, remaining: 12, requested: 52, queued: 52, failed: true }),
       "unclassified",
     ),
-  ).toEqual({ kind: "stopped-early", classified: 40, remaining: 12 });
+  ).toEqual({ kind: "stopped-early", classified: 40, remaining: 12, reason: null });
 });
 
 test("a default pass with nothing pending means everything is filed", () => {
@@ -58,5 +59,26 @@ test("a CLI that answered but matched nothing is not 'already sorted'", () => {
     classified: 0,
     costUsd: 0,
     leftOver: 0,
+  });
+});
+
+test("a pass that gave up carries the reason it was given", () => {
+  expect(
+    describeClassifyOutcome(
+      result({
+        classified: 0,
+        remaining: 22,
+        requested: 22,
+        queued: 22,
+        failed: true,
+        failureReason: "Claude Code CLI not found - pass --executable /path/to/claude",
+      }),
+      "unclassified",
+    ),
+  ).toEqual({
+    kind: "stopped-early",
+    classified: 0,
+    remaining: 22,
+    reason: "Claude Code CLI not found - pass --executable /path/to/claude",
   });
 });

--- a/src/lib/topics/classifyOutcome.ts
+++ b/src/lib/topics/classifyOutcome.ts
@@ -15,7 +15,13 @@ export type ClassifyScopeKind = "unclassified" | "all" | "selection";
  * itself differently depending on which one asked for it.
  */
 export type ClassifyOutcome =
-  | { readonly kind: "stopped-early"; readonly classified: number; readonly remaining: number }
+  | {
+      readonly kind: "stopped-early";
+      readonly classified: number;
+      readonly remaining: number;
+      /** Why it stopped, in one line, when the pass could say. */
+      readonly reason: string | null;
+    }
   /** Nothing was asked of the CLI because every conversation already has a topic. */
   | { readonly kind: "nothing-to-do" }
   /** Nothing was asked because none of the picked conversations could be sorted. */
@@ -33,7 +39,12 @@ export const describeClassifyOutcome = (
   scope: ClassifyScopeKind,
 ): ClassifyOutcome => {
   if (result.failed) {
-    return { kind: "stopped-early", classified: result.classified, remaining: result.remaining };
+    return {
+      kind: "stopped-early",
+      classified: result.classified,
+      remaining: result.remaining,
+      reason: result.failureReason,
+    };
   }
 
   // Nothing was asked of the CLI. For a default pass that means everything is

--- a/src/server/core/claude-code/functions/claudeInstallLocations.test.ts
+++ b/src/server/core/claude-code/functions/claudeInstallLocations.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "vitest";
+import {
+  type ClaudeInstallEnv,
+  claudeInstallLocations,
+  orderNodeVersionDirectories,
+  versionRootCandidates,
+} from "./claudeInstallLocations.ts";
+
+const posixJoin = (...segments: string[]) => segments.join("/");
+
+const env = (overrides?: Partial<ClaudeInstallEnv>): ClaudeInstallEnv => ({
+  home: "/home/user",
+  platform: "linux",
+  nvmDir: undefined,
+  fnmDir: undefined,
+  voltaHome: undefined,
+  pnpmHome: undefined,
+  xdgDataHome: undefined,
+  appData: undefined,
+  ...overrides,
+});
+
+describe("claudeInstallLocations", () => {
+  test("looks in the directories the Claude Code installers write to", () => {
+    const { files } = claudeInstallLocations(env(), posixJoin);
+
+    expect(files).toContain("/home/user/.claude/local/claude");
+    expect(files).toContain("/home/user/.local/bin/claude");
+  });
+
+  test("prefers a home install over a system one", () => {
+    const { files } = claudeInstallLocations(env(), posixJoin);
+
+    expect(files.indexOf("/home/user/.local/bin/claude")).toBeLessThan(
+      files.indexOf("/usr/local/bin/claude"),
+    );
+  });
+
+  test("expands every node version a version manager keeps", () => {
+    const { versionRoots } = claudeInstallLocations(env(), posixJoin);
+
+    expect(versionRoots).toContainEqual({
+      dir: "/home/user/.nvm/versions/node",
+      binSegments: ["bin"],
+    });
+    expect(versionRoots).toContainEqual({
+      dir: "/home/user/.local/share/fnm/node-versions",
+      binSegments: ["installation", "bin"],
+    });
+    expect(versionRoots).toContainEqual({
+      dir: "/home/user/.asdf/installs/nodejs",
+      binSegments: ["bin"],
+    });
+  });
+
+  test("honours the variables the version managers export", () => {
+    const { versionRoots } = claudeInstallLocations(
+      env({ nvmDir: "/opt/nvm", fnmDir: "/opt/fnm" }),
+      posixJoin,
+    );
+
+    expect(versionRoots).toContainEqual({ dir: "/opt/nvm/versions/node", binSegments: ["bin"] });
+    expect(versionRoots).toContainEqual({
+      dir: "/opt/fnm/node-versions",
+      binSegments: ["installation", "bin"],
+    });
+  });
+
+  test("follows PNPM_HOME and XDG_DATA_HOME when they are set", () => {
+    const withPnpmHome = claudeInstallLocations(env({ pnpmHome: "/opt/pnpm" }), posixJoin);
+    expect(withPnpmHome.files).toContain("/opt/pnpm/claude");
+
+    const withXdg = claudeInstallLocations(env({ xdgDataHome: "/opt/share" }), posixJoin);
+    expect(withXdg.files).toContain("/opt/share/pnpm/claude");
+    expect(withXdg.versionRoots).toContainEqual({
+      dir: "/opt/share/fnm/node-versions",
+      binSegments: ["installation", "bin"],
+    });
+  });
+
+  test("names the Windows launchers, and skips the unix system directories", () => {
+    const { files } = claudeInstallLocations(
+      env({ platform: "win32", appData: "C:/Users/user/AppData/Roaming" }),
+      posixJoin,
+    );
+
+    expect(files).toContain("C:/Users/user/AppData/Roaming/npm/claude.cmd");
+    expect(files).toContain("C:/Users/user/AppData/Roaming/npm/claude.exe");
+    expect(files).not.toContain("/usr/local/bin/claude");
+  });
+
+  test("offers nothing under a home it does not know", () => {
+    const { files, versionRoots } = claudeInstallLocations(env({ home: undefined }), posixJoin);
+
+    expect(files.every((file) => file.startsWith("/usr") || file.startsWith("/opt"))).toBe(true);
+    expect(versionRoots).toStrictEqual([]);
+  });
+});
+
+describe("orderNodeVersionDirectories", () => {
+  test("puts the newest node version first", () => {
+    expect(orderNodeVersionDirectories(["v20.19.5", "v24.18.1", "v22.22.0"])).toStrictEqual([
+      "v24.18.1",
+      "v22.22.0",
+      "v20.19.5",
+    ]);
+  });
+
+  test("compares each part as a number, not as text", () => {
+    expect(orderNodeVersionDirectories(["v9.0.0", "v10.0.0"])).toStrictEqual(["v10.0.0", "v9.0.0"]);
+    expect(orderNodeVersionDirectories(["v22.9.0", "v22.22.0"])).toStrictEqual([
+      "v22.22.0",
+      "v22.9.0",
+    ]);
+  });
+
+  test("keeps names that are not versions, last and in order", () => {
+    expect(orderNodeVersionDirectories(["lts", "v18.0.0", "alias"])).toStrictEqual([
+      "v18.0.0",
+      "lts",
+      "alias",
+    ]);
+  });
+});
+
+describe("versionRootCandidates", () => {
+  test("asks the newest node version before the ones it replaced", () => {
+    expect(
+      versionRootCandidates(
+        { dir: "/home/user/.nvm/versions/node", binSegments: ["bin"] },
+        ["v22.22.0", "v24.18.1"],
+        "linux",
+        posixJoin,
+      ),
+    ).toStrictEqual([
+      "/home/user/.nvm/versions/node/v24.18.1/bin/claude",
+      "/home/user/.nvm/versions/node/v22.22.0/bin/claude",
+    ]);
+  });
+
+  test("reaches through the layout the root declares", () => {
+    expect(
+      versionRootCandidates(
+        { dir: "/share/fnm/node-versions", binSegments: ["installation", "bin"] },
+        ["v22.11.0"],
+        "linux",
+        posixJoin,
+      ),
+    ).toStrictEqual(["/share/fnm/node-versions/v22.11.0/installation/bin/claude"]);
+  });
+});

--- a/src/server/core/claude-code/functions/claudeInstallLocations.ts
+++ b/src/server/core/claude-code/functions/claudeInstallLocations.ts
@@ -1,0 +1,175 @@
+/**
+ * Where `claude` lives when PATH does not carry it.
+ *
+ * A version manager keeps every global binary under the node version that
+ * installed it, so switching node takes that whole directory off PATH. Lantern
+ * needs node >=24 and Claude Code is usually installed under whatever node came
+ * before it, which puts the two on different versions and `which claude` on
+ * nothing — while the same machine still runs `claude` perfectly well from a
+ * shell on the other version. Probing the directories installers actually write
+ * to is what keeps topic naming working across that split.
+ *
+ * Pure, and handed its own `join` rather than reaching for `node:path`: the
+ * ordering is the whole point and is worth testing without a filesystem, a home
+ * directory or a platform behind it.
+ */
+
+/** The environment a lookup is allowed to read, resolved by the caller. */
+export type ClaudeInstallEnv = {
+  readonly home: string | undefined;
+  readonly platform: NodeJS.Platform;
+  readonly nvmDir: string | undefined;
+  readonly fnmDir: string | undefined;
+  readonly voltaHome: string | undefined;
+  readonly pnpmHome: string | undefined;
+  readonly xdgDataHome: string | undefined;
+  /** Windows only: where npm puts global shims. */
+  readonly appData: string | undefined;
+};
+
+/** A directory holding one subdirectory per installed node version. */
+export type ClaudeVersionRoot = {
+  readonly dir: string;
+  /** What sits between a version directory and the executable. */
+  readonly binSegments: readonly string[];
+};
+
+export type ClaudeInstallLocations = {
+  /** Absolute paths to try as they are, best first. */
+  readonly files: readonly string[];
+  /** Roots whose every child may hold an executable, newest version first. */
+  readonly versionRoots: readonly ClaudeVersionRoot[];
+};
+
+type Join = (...segments: string[]) => string;
+
+/**
+ * Windows resolves a bare command through PATHEXT, so a global install is a
+ * `.cmd` shim next to a `.exe`; elsewhere there is only the one name.
+ */
+const executableNames = (platform: NodeJS.Platform): readonly string[] =>
+  platform === "win32" ? ["claude.cmd", "claude.exe", "claude"] : ["claude"];
+
+const versionParts = (name: string): readonly number[] | null => {
+  const match = /^v?(\d+(?:\.\d+)*)$/.exec(name);
+  if (match === null) return null;
+
+  const digits = match[1];
+  if (digits === undefined) return null;
+
+  return digits.split(".").map(Number);
+};
+
+/**
+ * Newest first, so a machine with several node versions installed is asked
+ * about the one most likely to hold a current Claude Code.
+ *
+ * Names that are not versions — nvm's aliases, a stray directory — keep their
+ * order and go last rather than being dropped: a lookup that ignores a
+ * directory cannot find what is inside it.
+ */
+export const orderNodeVersionDirectories = (names: readonly string[]): readonly string[] => {
+  const versions: { name: string; parts: readonly number[] }[] = [];
+  const rest: string[] = [];
+
+  for (const name of names) {
+    const parts = versionParts(name);
+    if (parts === null) {
+      rest.push(name);
+      continue;
+    }
+    versions.push({ name, parts });
+  }
+
+  versions.sort((left, right) => {
+    const length = Math.max(left.parts.length, right.parts.length);
+    for (let index = 0; index < length; index += 1) {
+      const difference = (right.parts[index] ?? 0) - (left.parts[index] ?? 0);
+      if (difference !== 0) return difference;
+    }
+
+    return 0;
+  });
+
+  return [...versions.map((version) => version.name), ...rest];
+};
+
+/**
+ * Every place worth looking, ordered by how likely it is to be the install the
+ * user actually means: their own home first, the system last.
+ */
+export const claudeInstallLocations = (
+  env: ClaudeInstallEnv,
+  join: Join,
+): ClaudeInstallLocations => {
+  const names = executableNames(env.platform);
+  const files: string[] = [];
+  const versionRoots: ClaudeVersionRoot[] = [];
+
+  const addExecutablesIn = (directory: string | undefined): void => {
+    if (directory === undefined) return;
+    for (const name of names) {
+      files.push(join(directory, name));
+    }
+  };
+
+  const underHome = (...segments: string[]): string | undefined =>
+    env.home === undefined ? undefined : join(env.home, ...segments);
+
+  const shareDirectory = (...segments: string[]): string | undefined =>
+    env.xdgDataHome === undefined
+      ? underHome(".local", "share", ...segments)
+      : join(env.xdgDataHome, ...segments);
+
+  // Claude Code's own installers, which are version-manager independent and so
+  // the answer that stays right when node changes underneath.
+  addExecutablesIn(underHome(".claude", "local"));
+  addExecutablesIn(underHome(".local", "bin"));
+
+  addExecutablesIn(
+    env.voltaHome === undefined ? underHome(".volta", "bin") : join(env.voltaHome, "bin"),
+  );
+  addExecutablesIn(env.pnpmHome ?? shareDirectory("pnpm"));
+
+  if (env.platform === "win32") {
+    if (env.appData !== undefined) {
+      addExecutablesIn(join(env.appData, "npm"));
+    }
+  } else {
+    addExecutablesIn("/opt/homebrew/bin");
+    addExecutablesIn("/usr/local/bin");
+    addExecutablesIn("/usr/bin");
+  }
+
+  const addVersionRoot = (dir: string | undefined, binSegments: readonly string[]): void => {
+    if (dir === undefined) return;
+    versionRoots.push({ dir, binSegments });
+  };
+
+  addVersionRoot(
+    env.nvmDir === undefined
+      ? underHome(".nvm", "versions", "node")
+      : join(env.nvmDir, "versions", "node"),
+    ["bin"],
+  );
+  addVersionRoot(
+    env.fnmDir === undefined
+      ? shareDirectory("fnm", "node-versions")
+      : join(env.fnmDir, "node-versions"),
+    ["installation", "bin"],
+  );
+  addVersionRoot(underHome(".asdf", "installs", "nodejs"), ["bin"]);
+
+  return { files, versionRoots };
+};
+
+/** Every path a version root resolves to, newest node version first. */
+export const versionRootCandidates = (
+  root: ClaudeVersionRoot,
+  versionDirectories: readonly string[],
+  platform: NodeJS.Platform,
+  join: Join,
+): readonly string[] =>
+  orderNodeVersionDirectories(versionDirectories).flatMap((version) =>
+    executableNames(platform).map((name) => join(root.dir, version, ...root.binSegments, name)),
+  );

--- a/src/server/core/claude-code/models/ClaudeCode.test.ts
+++ b/src/server/core/claude-code/models/ClaudeCode.test.ts
@@ -3,6 +3,7 @@ import { NodeContext } from "@effect/platform-node";
 import { it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 import { describe, expect } from "vitest";
+import { testFileSystemLayer } from "../../../../testing/layers/testFileSystemLayer.ts";
 import { testPlatformLayer } from "../../../../testing/layers/testPlatformLayer.ts";
 import * as ClaudeCode from "./ClaudeCode.ts";
 
@@ -119,7 +120,7 @@ describe("ClaudeCode.Config", () => {
 
         expect(config.claudeCodeExecutablePath).toBe("/usr/local/bin/claude");
         expect(shellModes.every((mode) => mode === false)).toBe(true);
-      }).pipe(Effect.provide(testPlatformLayer())),
+      }).pipe(Effect.provide(Layer.mergeAll(testPlatformLayer(), testFileSystemLayer()))),
     );
 
     it.live("should correctly parse results of 'which claude' and 'claude --version'", () =>
@@ -144,7 +145,7 @@ describe("ClaudeCode.Config", () => {
           minor: 0,
           patch: 53,
         });
-      }).pipe(Effect.provide(testPlatformLayer())),
+      }).pipe(Effect.provide(Layer.mergeAll(testPlatformLayer(), testFileSystemLayer()))),
     );
 
     it.live("should skip npx shim path and use legitimate path with higher priority", () =>
@@ -174,7 +175,7 @@ describe("ClaudeCode.Config", () => {
           minor: 0,
           patch: 100,
         });
-      }).pipe(Effect.provide(testPlatformLayer())),
+      }).pipe(Effect.provide(Layer.mergeAll(testPlatformLayer(), testFileSystemLayer()))),
     );
 
     it.live("should use first npx shim path when all paths are npx shims", () =>
@@ -206,7 +207,7 @@ describe("ClaudeCode.Config", () => {
           minor: 0,
           patch: 50,
         });
-      }).pipe(Effect.provide(testPlatformLayer())),
+      }).pipe(Effect.provide(Layer.mergeAll(testPlatformLayer(), testFileSystemLayer()))),
     );
 
     it.live("should use project-local node_modules/.bin if it is the first result (not _npx)", () =>
@@ -236,7 +237,69 @@ describe("ClaudeCode.Config", () => {
           minor: 0,
           patch: 30,
         });
-      }).pipe(Effect.provide(testPlatformLayer())),
+      }).pipe(Effect.provide(Layer.mergeAll(testPlatformLayer(), testFileSystemLayer()))),
+    );
+  });
+
+  /**
+   * Lantern needs node >=24 and Claude Code is usually installed under whatever
+   * node came before it. The version manager that keeps the two apart takes
+   * `claude` off PATH for Lantern's process while leaving it installed — the
+   * state a machine is in right after `nvm use 24`.
+   */
+  describe("when claude is installed but not on PATH", () => {
+    const home = "/home/tester";
+    const installed = `${home}/.nvm/versions/node/v24.18.1/bin/claude`;
+
+    const emptyPathLookup = Layer.effect(
+      CommandExecutor.CommandExecutor,
+      Effect.map(CommandExecutor.CommandExecutor, (realExecutor) => ({
+        ...realExecutor,
+        string: () => Effect.succeed(""),
+      })),
+    ).pipe(Layer.provide(NodeContext.layer));
+
+    const installFileSystem = testFileSystemLayer({
+      exists: (path) => Effect.succeed(path === installed),
+      readDirectory: (path) =>
+        path === `${home}/.nvm/versions/node`
+          ? Effect.succeed(["v22.22.0", "v24.18.1"])
+          : Effect.succeed([]),
+    });
+
+    it.live("takes the newest node version's copy", () =>
+      Effect.gen(function* () {
+        const resolved = yield* ClaudeCode.resolveClaudeCodePath.pipe(
+          Effect.provide(emptyPathLookup),
+        );
+
+        expect(resolved).toBe(installed);
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(testPlatformLayer({ env: { HOME: home } }), installFileSystem),
+        ),
+      ),
+    );
+
+    it.live("says what to do when there is nothing to find anywhere", () =>
+      Effect.gen(function* () {
+        const failure = yield* ClaudeCode.resolveClaudeCodePath.pipe(
+          Effect.provide(emptyPathLookup),
+          Effect.flip,
+        );
+
+        expect(failure.message).toContain("--executable");
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            testPlatformLayer({ env: { HOME: home } }),
+            testFileSystemLayer({
+              exists: () => Effect.succeed(false),
+              readDirectory: () => Effect.succeed([]),
+            }),
+          ),
+        ),
+      ),
     );
   });
 });

--- a/src/server/core/claude-code/models/ClaudeCode.ts
+++ b/src/server/core/claude-code/models/ClaudeCode.ts
@@ -1,8 +1,14 @@
 import * as agentSdk from "@anthropic-ai/claude-agent-sdk";
-import { Command, Path } from "@effect/platform";
-import { Data, Effect } from "effect";
+import { Command, FileSystem, Path } from "@effect/platform";
+import { Data, Effect, Option } from "effect";
 import { uniq } from "es-toolkit";
+import { ApplicationContext } from "../../platform/services/ApplicationContext.ts";
+import { EnvService } from "../../platform/services/EnvService.ts";
 import { LanternOptionsService } from "../../platform/services/LanternOptionsService.ts";
+import {
+  claudeInstallLocations,
+  versionRootCandidates,
+} from "../functions/claudeInstallLocations.ts";
 import * as ClaudeCodeVersion from "./ClaudeCodeVersion.ts";
 
 type AgentSdkQuery = typeof agentSdk.query;
@@ -36,6 +42,54 @@ class ClaudeCodeAgentSdkNotSupportedError extends Data.TaggedError(
 )<{
   message: string;
 }> {}
+
+/**
+ * The known install directories, searched when PATH came back empty.
+ *
+ * Reading a handful of directories is cheap and only ever happens once PATH has
+ * already failed, which on a machine where `which claude` works is never.
+ */
+const searchInstalledClaudePaths = Effect.gen(function* () {
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  const context = yield* ApplicationContext;
+  const envService = yield* EnvService;
+
+  const join = (...segments: string[]) => path.join(...segments);
+
+  const locations = claudeInstallLocations(
+    {
+      home: yield* context.homeDirectory,
+      platform: context.platform,
+      nvmDir: yield* envService.getEnv("NVM_DIR"),
+      fnmDir: yield* envService.getEnv("FNM_DIR"),
+      voltaHome: yield* envService.getEnv("VOLTA_HOME"),
+      pnpmHome: yield* envService.getEnv("PNPM_HOME"),
+      xdgDataHome: yield* envService.getEnv("XDG_DATA_HOME"),
+      appData: yield* envService.getEnv("APPDATA"),
+    },
+    join,
+  );
+
+  // A directory that is not there, or that this user may not read, is an
+  // absence like any other — never a reason to fail the whole lookup.
+  const exists = (candidate: string) =>
+    fs.exists(candidate).pipe(Effect.catchAll(() => Effect.succeed(false)));
+
+  const fromVersionRoots = yield* Effect.forEach(locations.versionRoots, (root) =>
+    fs.readDirectory(root.dir).pipe(
+      Effect.map((versions) => versionRootCandidates(root, versions, context.platform, join)),
+      Effect.catchAll(() => Effect.succeed<readonly string[]>([])),
+    ),
+  );
+
+  const candidates = [...locations.files, ...fromVersionRoots.flat()];
+
+  return {
+    candidates,
+    found: Option.getOrUndefined(yield* Effect.findFirst(candidates, exists)),
+  };
+});
 
 export const resolveClaudeCodePath = Effect.gen(function* () {
   const path = yield* Path.Path;
@@ -80,16 +134,32 @@ export const resolveClaudeCodePath = Effect.gen(function* () {
   );
 
   const resolvedClaudePath = claudePaths.at(0);
-
-  if (resolvedClaudePath === undefined) {
-    return yield* Effect.fail(
-      new ClaudeCodePathNotFoundError({
-        message: "Claude Code CLI not found in any location",
-      }),
-    );
+  if (resolvedClaudePath !== undefined) {
+    return resolvedClaudePath;
   }
 
-  return resolvedClaudePath;
+  // PATH is not the whole machine. Claude Code is normally installed under one
+  // node version and Lantern needs another, so the version manager that keeps
+  // them apart is exactly what takes `claude` off PATH here while leaving it
+  // installed and runnable — see `claudeInstallLocations`.
+  const installed = yield* searchInstalledClaudePaths;
+  if (installed.found !== undefined) {
+    yield* Effect.logInfo(
+      `[ClaudeCode] not on PATH; using the installed copy at ${installed.found}`,
+    );
+    return installed.found;
+  }
+
+  // Where it looked belongs in the log, not in the message: the message is
+  // read off a status bar one line high, and a list of twenty paths there says
+  // less than the one thing the user can do about it.
+  yield* Effect.logDebug(`[ClaudeCode] looked in: ${installed.candidates.join(", ")}`);
+
+  return yield* Effect.fail(
+    new ClaudeCodePathNotFoundError({
+      message: "Claude Code CLI not found - pass --executable /path/to/claude",
+    }),
+  );
 });
 
 export const Config = Effect.gen(function* () {

--- a/src/server/core/claude-code/services/ClaudeCodeLifeCycleService.ts
+++ b/src/server/core/claude-code/services/ClaudeCodeLifeCycleService.ts
@@ -5,6 +5,7 @@ import { Context, Effect, Layer, Runtime } from "effect";
 import { ulid } from "ulid";
 import type { InferEffect } from "../../../lib/effect/types.ts";
 import { EventBus } from "../../events/services/EventBus.ts";
+import type { ApplicationContext } from "../../platform/services/ApplicationContext.ts";
 import type { EnvService } from "../../platform/services/EnvService.ts";
 import type { LanternOptionsService } from "../../platform/services/LanternOptionsService.ts";
 import type { SessionMetaService } from "../../session/services/SessionMetaService.ts";
@@ -33,6 +34,7 @@ const LayerImpl = Effect.gen(function* () {
     | CommandExecutor
     | SessionMetaService
     | ClaudeCodePermissionService
+    | ApplicationContext
     | EnvService
     | LanternOptionsService
   >();

--- a/src/server/core/platform/schema.ts
+++ b/src/server/core/platform/schema.ts
@@ -29,6 +29,18 @@ export const envSchema = z.object({
    * of its own, so this is the variable that moves it.
    */
   XDG_DATA_HOME: z.string().optional(),
+  /**
+   * Where the node version managers keep their installs. Read only to find a
+   * `claude` that PATH does not carry, which is the normal state of affairs
+   * when Claude Code was installed under a different node version than the one
+   * running Lantern.
+   */
+  NVM_DIR: z.string().optional(),
+  FNM_DIR: z.string().optional(),
+  VOLTA_HOME: z.string().optional(),
+  PNPM_HOME: z.string().optional(),
+  /** Windows names the per-user application directory here. */
+  APPDATA: z.string().optional(),
 });
 
 export type EnvSchema = z.infer<typeof envSchema>;

--- a/src/server/core/session/functions/classifyFailureMessage.test.ts
+++ b/src/server/core/session/functions/classifyFailureMessage.test.ts
@@ -14,8 +14,8 @@ describe("classifyFailureMessage", () => {
   });
 
   test("still explains itself when the CLI failed without saying why", () => {
-    expect(classifyFailureMessage("cli-unavailable", null)).toBe("the agent CLI could not be run");
-    expect(classifyFailureMessage("cli-unavailable", "   ")).toBe("the agent CLI could not be run");
+    expect(classifyFailureMessage("cli-unavailable", null)).toBe("The agent CLI could not be run");
+    expect(classifyFailureMessage("cli-unavailable", "   ")).toBe("The agent CLI could not be run");
   });
 
   test("keeps a long CLI complaint to one line", () => {
@@ -28,7 +28,7 @@ describe("classifyFailureMessage", () => {
 
   test("names an answer it could not read as topics", () => {
     expect(classifyFailureMessage("unusable-answer", null)).toBe(
-      "the agent CLI answered with nothing that could be read as topics",
+      "The agent CLI answered with nothing that could be read as topics",
     );
   });
 });

--- a/src/server/core/session/functions/classifyFailureMessage.test.ts
+++ b/src/server/core/session/functions/classifyFailureMessage.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { classifyFailureMessage } from "./classifyFailureMessage.ts";
+
+describe("classifyFailureMessage", () => {
+  test("says nothing about a pass that did not fail", () => {
+    expect(classifyFailureMessage(null, null)).toBeNull();
+    expect(classifyFailureMessage(null, "ignored")).toBeNull();
+  });
+
+  test("repeats what stopped the CLI from being asked", () => {
+    expect(
+      classifyFailureMessage("cli-unavailable", "Claude Code CLI not found - pass --executable"),
+    ).toBe("Claude Code CLI not found - pass --executable");
+  });
+
+  test("still explains itself when the CLI failed without saying why", () => {
+    expect(classifyFailureMessage("cli-unavailable", null)).toBe("the agent CLI could not be run");
+    expect(classifyFailureMessage("cli-unavailable", "   ")).toBe("the agent CLI could not be run");
+  });
+
+  test("keeps a long CLI complaint to one line", () => {
+    const detail = `Command failed\n${"x".repeat(400)}`;
+
+    const message = classifyFailureMessage("cli-unavailable", detail);
+
+    expect(message).toBe("Command failed");
+  });
+
+  test("names an answer it could not read as topics", () => {
+    expect(classifyFailureMessage("unusable-answer", null)).toBe(
+      "the agent CLI answered with nothing that could be read as topics",
+    );
+  });
+});

--- a/src/server/core/session/functions/classifyFailureMessage.ts
+++ b/src/server/core/session/functions/classifyFailureMessage.ts
@@ -1,0 +1,37 @@
+import type { ClassificationFailure } from "./runClassificationBatches.ts";
+
+/** As much of a CLI's complaint as a one-line status bar can carry. */
+const MAX_DETAIL_LENGTH = 160;
+
+/**
+ * Why a pass stopped, in words a user can act on.
+ *
+ * A pass that could not reach the CLI and a pass that reached it and got
+ * nonsense back both used to report themselves as a count: "Sorted 0, then
+ * stopped early." That is the number, not the reason, and the reason — most
+ * often that `claude` is installed under a node version Lantern is not running
+ * on — was only ever written to a log the board draws over.
+ */
+export const classifyFailureMessage = (
+  failure: ClassificationFailure | null,
+  detail: string | null,
+): string | null => {
+  switch (failure) {
+    case null:
+      return null;
+    case "unusable-answer":
+      return "the agent CLI answered with nothing that could be read as topics";
+    case "cli-unavailable": {
+      // Command failures arrive as several lines of stderr. The first line is
+      // the one that names the problem; the rest is the transcript.
+      const firstLine = (detail ?? "").split("\n")[0]?.trim() ?? "";
+
+      return firstLine === ""
+        ? "the agent CLI could not be run"
+        : firstLine.slice(0, MAX_DETAIL_LENGTH);
+    }
+    default:
+      failure satisfies never;
+      return null;
+  }
+};

--- a/src/server/core/session/functions/classifyFailureMessage.ts
+++ b/src/server/core/session/functions/classifyFailureMessage.ts
@@ -20,14 +20,14 @@ export const classifyFailureMessage = (
     case null:
       return null;
     case "unusable-answer":
-      return "the agent CLI answered with nothing that could be read as topics";
+      return "The agent CLI answered with nothing that could be read as topics";
     case "cli-unavailable": {
       // Command failures arrive as several lines of stderr. The first line is
       // the one that names the problem; the rest is the transcript.
       const firstLine = (detail ?? "").split("\n")[0]?.trim() ?? "";
 
       return firstLine === ""
-        ? "the agent CLI could not be run"
+        ? "The agent CLI could not be run"
         : firstLine.slice(0, MAX_DETAIL_LENGTH);
     }
     default:

--- a/src/server/core/session/functions/runClassificationBatches.test.ts
+++ b/src/server/core/session/functions/runClassificationBatches.test.ts
@@ -34,7 +34,13 @@ describe("runClassificationBatches", () => {
 
       expect(askedSizes).toEqual([40, 40, 10]);
       expect(topicReads).toBe(3);
-      expect(outcome).toEqual({ classified: 90, batches: 3, costUsd: 0, failed: false });
+      expect(outcome).toEqual({
+        classified: 90,
+        batches: 3,
+        costUsd: 0,
+        failed: false,
+        failure: null,
+      });
     }),
   );
 
@@ -52,7 +58,13 @@ describe("runClassificationBatches", () => {
       });
 
       expect(asks).toBe(2);
-      expect(outcome).toEqual({ classified: 40, batches: 1, costUsd: 0.002, failed: true });
+      expect(outcome).toEqual({
+        classified: 40,
+        batches: 1,
+        costUsd: 0.002,
+        failed: true,
+        failure: "cli-unavailable",
+      });
     }),
   );
 
@@ -70,7 +82,13 @@ describe("runClassificationBatches", () => {
       });
 
       expect(asks).toBe(1);
-      expect(outcome).toEqual({ classified: 0, batches: 1, costUsd: 0.001, failed: true });
+      expect(outcome).toEqual({
+        classified: 0,
+        batches: 1,
+        costUsd: 0.001,
+        failed: true,
+        failure: "unusable-answer",
+      });
     }),
   );
 
@@ -101,7 +119,13 @@ describe("runClassificationBatches", () => {
       });
 
       expect(asks).toBe(0);
-      expect(outcome).toEqual({ classified: 0, batches: 0, costUsd: 0, failed: false });
+      expect(outcome).toEqual({
+        classified: 0,
+        batches: 0,
+        costUsd: 0,
+        failed: false,
+        failure: null,
+      });
     }),
   );
 

--- a/src/server/core/session/functions/runClassificationBatches.ts
+++ b/src/server/core/session/functions/runClassificationBatches.ts
@@ -24,11 +24,19 @@ export type ClassificationBatchDeps<R = never> = {
   readonly store: (batch: readonly ClassificationCandidate[], answer: string) => number;
 };
 
+/**
+ * Why a pass stopped before the end. `failed` says that it did; this says what
+ * to tell the user, and the two are worth telling apart — "the CLI could not be
+ * asked" and "the CLI answered something unusable" are fixed differently.
+ */
+export type ClassificationFailure = "cli-unavailable" | "unusable-answer";
+
 export type ClassificationBatchOutcome = {
   readonly classified: number;
   readonly batches: number;
   readonly costUsd: number;
   readonly failed: boolean;
+  readonly failure: ClassificationFailure | null;
 };
 
 /**
@@ -45,7 +53,7 @@ export const runClassificationBatches = <R = never>(
     let classified = 0;
     let batches = 0;
     let costUsd = 0;
-    let failed = false;
+    let failure: ClassificationFailure | null = null;
 
     for (let offset = 0; offset < candidates.length; offset += batchSize) {
       const batch = candidates.slice(offset, offset + batchSize);
@@ -53,7 +61,7 @@ export const runClassificationBatches = <R = never>(
 
       const answer = yield* deps.ask(buildClassificationPrompt(batch, deps.existingTopics()));
       if (answer === null) {
-        failed = true;
+        failure = "cli-unavailable";
         break;
       }
 
@@ -65,10 +73,10 @@ export const runClassificationBatches = <R = never>(
       // An unusable answer means the next batch would likely fail the same way;
       // stopping keeps a broken run cheap.
       if (stored === 0) {
-        failed = true;
+        failure = "unusable-answer";
         break;
       }
     }
 
-    return { classified, batches, costUsd, failed };
+    return { classified, batches, costUsd, failed: failure !== null, failure };
   });

--- a/src/server/core/session/schema.ts
+++ b/src/server/core/session/schema.ts
@@ -59,6 +59,12 @@ export type ClassifyResult = {
   /** Conversations this pass queued. `requested - queued` were left for later. */
   queued: number;
   failed: boolean;
+  /**
+   * Why it failed, in one line, or null when it did not. A count alone cannot
+   * tell "the CLI is not installed where Lantern can see it" from "the CLI
+   * answered badly", and those are fixed differently.
+   */
+  failureReason: string | null;
 };
 
 export const sessionMetaSchema = z.object({

--- a/src/server/core/session/services/TopicClassifierService.test.ts
+++ b/src/server/core/session/services/TopicClassifierService.test.ts
@@ -196,6 +196,7 @@ describe("TopicClassifierService", () => {
           requested: 1,
           queued: 1,
           failed: false,
+          failureReason: null,
         });
         // The already-filed conversation kept the label it had.
         expect(
@@ -409,6 +410,7 @@ describe("TopicClassifierService", () => {
           requested: 0,
           queued: 0,
           failed: false,
+          failureReason: null,
         });
       }).pipe(
         Effect.provide(

--- a/src/server/core/session/services/TopicClassifierService.test.ts
+++ b/src/server/core/session/services/TopicClassifierService.test.ts
@@ -7,7 +7,7 @@ import { testPlatformLayer } from "../../../../testing/layers/testPlatformLayer.
 import { type DrizzleDb, DrizzleService } from "../../../lib/db/DrizzleService.ts";
 import { projects, sessionTopics, sessions } from "../../../lib/db/schema.ts";
 import { claudeCodeSourceAdapter } from "../../source/adapters/claude-code/ClaudeCodeSourceAdapter.ts";
-import type { SourceAdapter } from "../../source/models/SourceAdapter.ts";
+import { HeadlessUnavailableError, type SourceAdapter } from "../../source/models/SourceAdapter.ts";
 import { SourceRegistry } from "../../source/services/SourceRegistry.ts";
 import { CLASSIFIER_MARKER } from "../functions/buildClassificationPrompt.ts";
 import { TopicClassifierService } from "./TopicClassifierService.ts";
@@ -18,6 +18,29 @@ import { TopicClassifierService } from "./TopicClassifierService.ts";
  * offers no headless mode.
  */
 const noHeadlessAdapter: SourceAdapter = { ...claudeCodeSourceAdapter, headless: undefined };
+
+/** The reason a real resolution failure carries, and the one a user can act on. */
+const UNRESOLVABLE_REASON = "Claude Code CLI not found - pass --executable /path/to/claude";
+
+/**
+ * An adapter that offers a headless mode and then cannot produce an executable,
+ * which is what an install under another node version looks like from here.
+ */
+const unresolvableAdapter: SourceAdapter = {
+  ...claudeCodeSourceAdapter,
+  headless: {
+    executable: () =>
+      Effect.fail(
+        new HeadlessUnavailableError({
+          sourceId: claudeCodeSourceAdapter.id,
+          reason: UNRESOLVABLE_REASON,
+        }),
+      ),
+    // Never reached: resolving the executable is what fails.
+    args: (prompt) => [prompt],
+    parse: (stdout) => ({ text: stdout, costUsd: 0 }),
+  },
+};
 
 /**
  * A runner that really does spawn something — `echo`, printing the answer the
@@ -324,6 +347,30 @@ describe("TopicClassifierService", () => {
               { id: "new-one", customTitle: "Rework the topic classifier" },
             ],
             noHeadlessAdapter,
+          ),
+        ),
+      ),
+    );
+
+    /**
+     * A forced pass learns the CLI cannot answer before any batch runs, so its
+     * reason comes from the wipe check rather than from a failed call. It has to
+     * be the same actionable sentence either way: "Redo all" is the button
+     * pressed on the machine where `claude` is installed out of Lantern's sight.
+     */
+    it.effect("says why a forced pass could not start, not just that it did not", () =>
+      Effect.gen(function* () {
+        const classifier = yield* TopicClassifierService;
+
+        const result = yield* classifier.classify({ scope: { kind: "all" } });
+
+        expect(result.failed).toBe(true);
+        expect(result.failureReason).toBe(UNRESOLVABLE_REASON);
+      }).pipe(
+        Effect.provide(
+          testLayer(
+            [{ id: "new-one", customTitle: "Rework the topic classifier" }],
+            unresolvableAdapter,
           ),
         ),
       ),

--- a/src/server/core/session/services/TopicClassifierService.ts
+++ b/src/server/core/session/services/TopicClassifierService.ts
@@ -273,22 +273,29 @@ const LayerImpl = Effect.gen(function* () {
    *
    * Wiping first and asking afterwards is how "Redo all" with no CLI installed
    * used to lose every topic and file none.
+   *
+   * The reason the CLI could not answer is written to `failureDetail` rather
+   * than only logged: this is the one path that finds out before a batch is
+   * ever run, and "Redo all" is the very button somebody presses on a machine
+   * where `claude` is installed somewhere Lantern cannot see.
    */
-  const wipeForForcedPass = Effect.gen(function* () {
-    const usable = yield* classifierRunner.pipe(
-      Effect.as(true),
-      Effect.catchAll((error) =>
-        Effect.logError(`[TopicClassifier] not wiping topics: ${String(error)}`).pipe(
-          Effect.as(false),
+  const wipeForForcedPass = (failureDetail: Ref.Ref<string | null>) =>
+    Effect.gen(function* () {
+      const usable = yield* classifierRunner.pipe(
+        Effect.as(true),
+        Effect.catchAll((error) =>
+          Effect.logError(`[TopicClassifier] not wiping topics: ${String(error)}`).pipe(
+            Effect.zipRight(Ref.set(failureDetail, describeClassifierError(error))),
+            Effect.as(false),
+          ),
         ),
-      ),
-    );
-    if (!usable) return null;
+      );
+      if (!usable) return null;
 
-    const snapshot = storedTopics();
-    db.delete(sessionTopics).run();
-    return snapshot;
-  });
+      const snapshot = storedTopics();
+      db.delete(sessionTopics).run();
+      return snapshot;
+    });
 
   /**
    * Classifies what the scope resolves to, in batches, capped per pass. What the
@@ -311,7 +318,7 @@ const LayerImpl = Effect.gen(function* () {
          */
         const failureDetail = yield* Ref.make<string | null>(null);
 
-        const snapshot = forced ? yield* wipeForForcedPass : null;
+        const snapshot = forced ? yield* wipeForForcedPass(failureDetail) : null;
         if (forced && snapshot === null) {
           return {
             classified: 0,
@@ -321,7 +328,7 @@ const LayerImpl = Effect.gen(function* () {
             requested: 0,
             queued: 0,
             failed: true,
-            failureReason: classifyFailureMessage("cli-unavailable", null),
+            failureReason: classifyFailureMessage("cli-unavailable", yield* Ref.get(failureDetail)),
           } satisfies ClassifyResult;
         }
 

--- a/src/server/core/session/services/TopicClassifierService.ts
+++ b/src/server/core/session/services/TopicClassifierService.ts
@@ -1,11 +1,12 @@
 import { Command } from "@effect/platform";
 import { and, desc, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, Ref } from "effect";
 import { MAX_CLASSIFY_PER_PASS } from "../../../../lib/topics/classifyLimits.ts";
 import { DrizzleService } from "../../../lib/db/DrizzleService.ts";
 import { projects, sessionTopics, sessions } from "../../../lib/db/schema.ts";
 import type { InferEffect } from "../../../lib/effect/types.ts";
 import { UserConfigService } from "../../platform/services/UserConfigService.ts";
+import { HeadlessUnavailableError } from "../../source/models/SourceAdapter.ts";
 import { CLAUDE_CODE_SOURCE_ID, sourceIdSchema } from "../../source/models/SourceId.ts";
 import { SourceRegistry } from "../../source/services/SourceRegistry.ts";
 import {
@@ -17,6 +18,7 @@ import {
   selectPassCandidates,
   toClassificationCandidate,
 } from "../functions/classificationCandidates.ts";
+import { classifyFailureMessage } from "../functions/classifyFailureMessage.ts";
 import type { ClassifyScope } from "../functions/classifyScope.ts";
 import { normalizeTopicIcon } from "../functions/groupConversationsByTopic.ts";
 import { runClassificationBatches } from "../functions/runClassificationBatches.ts";
@@ -41,6 +43,17 @@ import type { ClassifyResult } from "../schema.ts";
 
 /** Conversations per CLI call. Large enough to be cheap, small enough to stay accurate. */
 const BATCH_SIZE = 40;
+
+/**
+ * The sentence to show for a failed call. `HeadlessUnavailableError` carries
+ * the useful one — why the CLI could not be resolved — under `reason`, where a
+ * plain `String(error)` would print the tag instead.
+ */
+const describeClassifierError = (error: unknown): string => {
+  if (error instanceof HeadlessUnavailableError) return error.reason;
+
+  return error instanceof Error ? error.message : String(error);
+};
 
 /**
  * Only Claude Code takes a model flag here. The others are driven by whatever
@@ -291,6 +304,13 @@ const LayerImpl = Effect.gen(function* () {
         const max = options.maxCandidates ?? MAX_CLASSIFY_PER_PASS;
         const forced = options.scope.kind === "all";
 
+        /**
+         * What the CLI said when it could not answer. Held here rather than
+         * returned by `ask`, whose null is all `runClassificationBatches` needs
+         * to know — the words are for the user, not for the loop.
+         */
+        const failureDetail = yield* Ref.make<string | null>(null);
+
         const snapshot = forced ? yield* wipeForForcedPass : null;
         if (forced && snapshot === null) {
           return {
@@ -301,6 +321,7 @@ const LayerImpl = Effect.gen(function* () {
             requested: 0,
             queued: 0,
             failed: true,
+            failureReason: classifyFailureMessage("cli-unavailable", null),
           } satisfies ClassifyResult;
         }
 
@@ -312,6 +333,7 @@ const LayerImpl = Effect.gen(function* () {
             runClassifier(prompt).pipe(
               Effect.catchAll((error) =>
                 Effect.logError(`[TopicClassifier] CLI failed: ${String(error)}`).pipe(
+                  Effect.zipRight(Ref.set(failureDetail, describeClassifierError(error))),
                   Effect.as(null),
                 ),
               ),
@@ -333,6 +355,7 @@ const LayerImpl = Effect.gen(function* () {
           requested,
           queued: queued.length,
           failed: outcome.failed,
+          failureReason: classifyFailureMessage(outcome.failure, yield* Ref.get(failureDetail)),
         } satisfies ClassifyResult;
       }),
     );

--- a/src/server/core/source/models/SourceAdapter.ts
+++ b/src/server/core/source/models/SourceAdapter.ts
@@ -1,6 +1,7 @@
 import type { CommandExecutor, FileSystem, Path } from "@effect/platform";
 import { Data, type Effect } from "effect";
 import type { ApplicationContext } from "../../platform/services/ApplicationContext.ts";
+import type { EnvService } from "../../platform/services/EnvService.ts";
 import type { LanternOptionsService } from "../../platform/services/LanternOptionsService.ts";
 import type {
   SourceChange,
@@ -122,10 +123,15 @@ export type SourceAdapter = {
 
 /**
  * What resolving and running a CLI needs, on top of what reading files needs:
- * a process to run `which`, and the options that can name an executable
- * outright.
+ * a process to run `which`, the options that can name an executable outright,
+ * and the environment the version managers describe their installs in — PATH
+ * alone does not find a CLI installed under another node version.
  */
-export type HeadlessEnv = SourceEnv | CommandExecutor.CommandExecutor | LanternOptionsService;
+export type HeadlessEnv =
+  | SourceEnv
+  | CommandExecutor.CommandExecutor
+  | LanternOptionsService
+  | EnvService;
 
 export type HeadlessAnswer = {
   readonly text: string;

--- a/src/testing/layers/testPlatformLayer.ts
+++ b/src/testing/layers/testPlatformLayer.ts
@@ -79,6 +79,18 @@ export const testPlatformLayer = (overrides?: {
             return overrides?.env?.CODEX_HOME ?? undefined;
           case "XDG_DATA_HOME":
             return overrides?.env?.XDG_DATA_HOME ?? undefined;
+          // Where the node version managers keep their installs, which is where
+          // a `claude` that PATH does not carry is looked for.
+          case "NVM_DIR":
+            return overrides?.env?.NVM_DIR ?? undefined;
+          case "FNM_DIR":
+            return overrides?.env?.FNM_DIR ?? undefined;
+          case "VOLTA_HOME":
+            return overrides?.env?.VOLTA_HOME ?? undefined;
+          case "PNPM_HOME":
+            return overrides?.env?.PNPM_HOME ?? undefined;
+          case "APPDATA":
+            return overrides?.env?.APPDATA ?? undefined;
           case "LANTERN_TERMINAL_DISABLED":
             return overrides?.env?.LANTERN_TERMINAL_DISABLED ?? undefined;
           default:

--- a/src/web/lib/api/useClassifyTopics.ts
+++ b/src/web/lib/api/useClassifyTopics.ts
@@ -53,6 +53,11 @@ export const useClassifyTopics = () => {
             message: "Sorted {count}, then stopped early. {remaining} still have no topic.",
             values: { count: outcome.classified, remaining: outcome.remaining },
           }),
+          // The reason comes from the CLI itself, so it is not translated and
+          // does not belong in the headline. It is still the only part that
+          // says what to do — most often that Claude Code is installed where
+          // Lantern cannot see it.
+          outcome.reason === null ? undefined : { description: outcome.reason },
         );
         return;
       }


### PR DESCRIPTION
Recovered from uncommitted work sitting in the local checkout on `docs/tighten-readme`, rebased onto current `main` as a single commit. Nothing here was written for this PR — it is existing work, preserved and verified.

## What it does

A pass that could not reach the agent CLI, and a pass that reached it and got nonsense back, both reported themselves as a count:

```
Sorted 0, then stopped early. 22 still have no topic.
```

That is the number, not the reason. The actual cause — most often that `claude` is installed under a node version Lantern is not running on — went only to a log the terminal board draws over, so it was invisible exactly where it mattered.

Now the outcome carries a reason, and the board leads with it:

```
Claude Code CLI not found - pass --executable /path/to/claude. 22 still have no topic.
```

## Shape of the change

- `ClassifyOutcome.stopped-early` gains a `reason` field; `null` keeps the old count-based wording, so nothing regresses when the cause is unknown.
- New `classifyFailureMessage.ts` turns a `ClassificationFailure` plus raw stderr into one actionable line, trimming multi-line command output to the first line that names the problem (capped at 160 chars for a status bar).
- New `claudeInstallLocations.ts` probes where the CLI actually lives, so the message can name the fix rather than the symptom.
- Reason is threaded through `runClassificationBatches`, `TopicClassifierService`, the session/platform schemas, and surfaced in the web UI via `useClassifyTopics`.
- All six locale catalogs updated.

## Verification

Against this branch, rebased on `main`:

- `pnpm gatecheck check` — oxfmt, oxlint, typecheck, vitest all pass
- `./scripts/lingui-check.sh` — translations complete
- 1709 tests passing (main is at 1703; the 6 new ones cover the reason paths)