### PR TITLE
feat: start the terminal board and the web UI from a bare lantern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ docker/workspace/.git/
 # Build output from scripts/build-packages.sh
 packaging/staging/
 packaging/dist/
+
+# Worktrees the Claude Code harness checks out inside the repo. A second copy of
+# the tree is not part of this one, and lint and the test run pick it up as
+# though it were.
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ $ lantern
 ```
 
 One column per topic, conversations as rows, newest topic first. Press `R` to resume a conversation
-in place and come back to the board when you leave it. No server, no port, no browser.
-[The board](docs/board.md) has the rest of the keys.
+in place and come back to the board when you leave it. [The board](docs/board.md) has the rest of the
+keys.
 
-There is a [web UI](docs/web-ui.md) too — the same data, with a full session viewer, search and cost
-breakdowns — for when a terminal is the wrong shape for what you are doing.
+The [web UI](docs/web-ui.md) starts behind it and prints its address — the same data, with a full
+session viewer, search and cost breakdowns, for when a terminal is the wrong shape for what you are
+doing. `lantern --cli-only` leaves it out: no server, no port, no browser.
 
 <p align="center">
   <img src="docs/screenshots/topics.jpg" alt="Topics grouped by subject, each with an icon and a conversation count" width="100%">
@@ -49,7 +50,7 @@ breakdowns — for when a terminal is the wrong shape for what you are doing.
 With Node.js 24 or newer already present, nothing to install:
 
 ```bash
-npx lantern-viewer browse
+npx lantern-viewer
 ```
 
 On a first run Lantern reads your logs into its own cache, then draws the board.
@@ -77,9 +78,9 @@ lantern init               # optional: set Lantern up, and remember the answers
 lantern upgrade            # move to the latest release
 ```
 
-- **`lantern`** — starts the web server, prints its address, and draws the board over it. Quitting the
-  board stops both. `--cli-only` and `--server-only` ask for one half; passing both is an error. With
-  nothing to draw on — a container, a pipe, CI — it starts the server alone.
+- **`lantern`** — starts the web server, prints its address, and draws the board over it. Quitting
+  the board stops both. `--cli-only` and `--server-only` ask for one half; asking for both is
+  refused. With nothing to draw on — a container, a pipe, CI — it starts the server alone.
 - **`browse`** — alias `b`, and the same thing as `--cli-only`. Takes `--claude-dir`, `--executable`,
   `--source` and `--verbose`, on either side of the command name.
 - **`init`** — never required: every setting it writes has a working default, and the board never stops
@@ -122,6 +123,10 @@ Claude Code login for better topic names instead. Nothing runs automatically.
 
 None of that applies to `lantern --cli-only` (or `lantern browse`), which opens no port and serves
 nothing.
+
+If you have run `lantern init` and told it to bind beyond `localhost`, that answer is stored, and a
+bare `lantern` now starts a server where `lantern browse` started none. Check `~/.lantern/config.json`
+before the first run of a version with this in it, or use `--cli-only` to open no port at all.
 
 The threat model and how to report a vulnerability privately are in [SECURITY.md](SECURITY.md). Please
 use [GitHub Security Advisories](https://github.com/WildChildForLife/lantern/security/advisories/new)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ optionally [five others](docs/agents.md) — and groups every conversation by **
 by which folder it happened to start in. It runs where you already are: a terminal.
 
 ```console
-$ lantern browse
+$ lantern
 ```
 
 ```text
@@ -64,21 +64,25 @@ brew install wildchildforlife/tap/lantern-viewer    # macOS or linuxbrew, brings
 For Docker, Windows, `aarch64`, building from source, or which platforms support the web UI's in-app
 terminal, see [Install](docs/install.md).
 
-Nothing to configure afterwards — `lantern browse` works out of the box. Only the optional AI topic
+Nothing to configure afterwards — `lantern` works out of the box. Only the optional AI topic
 naming needs Claude Code installed and signed in.
 
 ## Commands
 
 ```bash
-lantern browse             # the board, in your terminal
+lantern                    # the board in your terminal, with the web UI behind it
+lantern --cli-only         # the board alone, no port opened
+lantern --server-only      # the web UI alone, for a container or a service file
 lantern init               # optional: set Lantern up, and remember the answers
 lantern upgrade            # move to the latest release
-lantern [options]          # start the web UI
 ```
 
-- **`browse`** — alias `b`. Takes `--claude-dir`, `--executable`, `--source` and `--verbose`, on
-  either side of the command name.
-- **`init`** — never required: every setting it writes has a working default, and `browse` never stops
+- **`lantern`** — starts the web server, prints its address, and draws the board over it. Quitting the
+  board stops both. `--cli-only` and `--server-only` ask for one half; passing both is an error. With
+  nothing to draw on — a container, a pipe, CI — it starts the server alone.
+- **`browse`** — alias `b`, and the same thing as `--cli-only`. Takes `--claude-dir`, `--executable`,
+  `--source` and `--verbose`, on either side of the command name.
+- **`init`** — never required: every setting it writes has a working default, and the board never stops
   to ask for one. Run it to change the port, bind address or set of agent CLIs.
 - **`upgrade`** — runs the package manager that installed Lantern. Anything it did not install is left
   alone with the right command printed instead.
@@ -116,7 +120,8 @@ Claude Code login for better topic names instead. Nothing runs automatically.
 > password, or keep it behind a VPN such as Tailscale. `--terminal-unrestricted` removes the guard
 > rails from bash sessions, so treat it as widening that same hole.
 
-None of that applies to `lantern browse`, which opens no port and serves nothing.
+None of that applies to `lantern --cli-only` (or `lantern browse`), which opens no port and serves
+nothing.
 
 The threat model and how to report a vulnerability privately are in [SECURITY.md](SECURITY.md). Please
 use [GitHub Security Advisories](https://github.com/WildChildForLife/lantern/security/advisories/new)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Start at the [README](../README.md) for what Lantern is and how to install it.
 | Document                          | Covers                                                                      |
 | --------------------------------- | --------------------------------------------------------------------------- |
 | [Install](install.md)             | npm, Homebrew, Docker, Windows, from source, and per-platform support       |
-| [The board](board.md)             | `lantern browse` — keys, resuming, sorting into topics                      |
+| [The board](board.md)             | `lantern` in your terminal — keys, resuming, sorting into topics            |
 | [The web UI](web-ui.md)           | What the server gives you that the terminal does not                        |
 | [Configuration](configuration.md) | The setup wizard, every option, and how a setting is resolved               |
 | [Agent CLIs](agents.md)           | The six CLIs Lantern reads, where their history lives, multi-machine setups |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -71,7 +71,7 @@ that moves them.
 Enable the ones you want in settings, or scope a single run with `--source`:
 
 ```bash
-lantern browse --source claude-code --source codex
+lantern --source claude-code --source codex
 ```
 
 In Docker each one needs its own mount, since only `~/.claude` is mounted by default:

--- a/docs/board.md
+++ b/docs/board.md
@@ -1,8 +1,12 @@
 # The board in your terminal
 
-`lantern browse` draws the same board the web UI does, without starting a server or opening a
-browser. It takes the whole terminal while it is up, on the same alternate screen `less` and `vim`
-use, and gives your scrollback back when you quit.
+`lantern` draws the same board the web UI does, without opening a browser. It takes the whole
+terminal while it is up, on the same alternate screen `less` and `vim` use, and gives your scrollback
+back when you quit.
+
+A bare `lantern` starts the web server behind the board and prints its address before drawing, so one
+word gets you both and quitting the board stops both. `lantern --cli-only` — or `lantern browse`,
+which is the same thing — draws the board on its own, opening no port at all.
 
 ```text
  Lantern  6 topics · 69 conversations · enter: resume here
@@ -43,7 +47,7 @@ right; the keys are unchanged.
 
 `R` lends the terminal to the session rather than giving it away: when you leave `claude`, the same
 board comes back — same topic, same conversation, same filter — with the logs re-read, so you can
-resume something else without starting `lantern browse` again.
+resume something else without starting the board again.
 
 A conversation is always resumed **in the directory it ran in** — `claude --resume` looks a session
 up by that directory, so anywhere else it reports the conversation as missing. If that folder has
@@ -82,6 +86,7 @@ menu in between, and each of the three has its own key as well.
 
 ## Options the board reads
 
-`lantern browse` reads `--claude-dir`, `--executable`, `--source` and `--verbose`, on either side of
-the command name. The port and bind address are ignored: the board listens on nothing. See
+The board reads `--claude-dir`, `--executable`, `--source` and `--verbose` — on either side of the
+command name, when you spell it as `lantern browse`. The port and bind address mean nothing to the
+board itself; with `--cli-only` nothing listens on them at all. See
 [Configuration](configuration.md) for the full table.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,9 +6,9 @@ a fresh machine and never stops to ask a question.
 ## The setup wizard
 
 What the offer covers is the web UI, which has more to decide: the first launch that both starts a
-server and has a terminal to ask at walks you through which agent CLIs to read, where they keep their logs,
-which port and address to bind, and whether to enable the in-app terminal. Every question arrives
-with the answer already detected, so the fast path is Enter a few times.
+server and has a terminal to ask at walks you through which agent CLIs to read, where they keep
+their logs, which port and address to bind, and whether to enable the in-app terminal. Every question
+arrives with the answer already detected, so the fast path is Enter a few times.
 
 The answers go in `~/.lantern/config.json` (and the CLI selection in
 `~/.lantern/sources/sources.json`, the same file the settings panel writes). Run `lantern init` at any

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,12 @@
 # Configuration
 
-Setup is optional. Everything Lantern needs has a default, so `lantern browse` goes straight to the
-board on a fresh machine and never stops to ask a question.
+Setup is optional. Everything Lantern needs has a default, so `lantern` goes straight to the board on
+a fresh machine and never stops to ask a question.
 
 ## The setup wizard
 
-What the offer covers is the web UI, which has more to decide: the first time you run `lantern` with
-no command at a terminal it walks you through which agent CLIs to read, where they keep their logs,
+What the offer covers is the web UI, which has more to decide: the first launch that both starts a
+server and has a terminal to ask at walks you through which agent CLIs to read, where they keep their logs,
 which port and address to bind, and whether to enable the in-app terminal. Every question arrives
 with the answer already detected, so the fast path is Enter a few times.
 
@@ -36,8 +36,9 @@ Nothing prompts without a terminal attached, so Docker, CI and `npx … | tee` s
 | (none)                      | `NO_UPDATE_NOTIFIER`            | Never mention that a new version exists                     | mentioned   |
 | (none)                      | `LANTERN_NO_UPDATE_NOTIFIER`    | The same thing, under Lantern's own name                    | mentioned   |
 
-`lantern browse` reads `--claude-dir`, `--executable`, `--source` and `--verbose`; the rest belong to
-the server. The port and bind address are ignored by the board, which listens on nothing.
+The board reads `--claude-dir`, `--executable`, `--source` and `--verbose`; the rest belong to the
+server. The port and bind address are ignored by the board itself, and with `--cli-only` — or
+`lantern browse` — nothing listens on them at all.
 
 Flag-style environment variables are on for `1` or `true` and off otherwise.
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -28,10 +28,10 @@ node dist/main.js --cli-only           # terminal board alone
 ```
 
 `pnpm dev` exists and runs both halves in parallel with `run-p` — Vite for the frontend on
-`DEV_FE_PORT` (3400), and `node --watch src/server/main.ts --server-only` for the backend on `DEV_BE_PORT` (3401),
-with `/api` proxied from the first to the second. It is fine for frontend work, but session process
-management shares memory between processes, so anything touching that needs verifying against a real
-build.
+`DEV_FE_PORT` (3400), and `node --watch src/server/main.ts --server-only` for the backend on
+`DEV_BE_PORT` (3401), with `/api` proxied from the first to the second. It is fine for frontend
+work, but session process management shares memory between processes, so anything touching that
+needs verifying against a real build.
 
 To work against the bundled fixtures instead of your own conversations:
 
@@ -43,6 +43,12 @@ node dist/main.js --server-only --port 4100 --claude-dir ./fixtures/claude-home
 The fixture conversations record invented working directories, so the board will refuse to resume
 any of them — that refusal is correct behaviour, not a fault. Point it at your own history to
 exercise resuming.
+
+> `--claude-dir` moves what the **board** caches, but not what the **server** caches. The server
+> builds its database layer before it has read the flag, so `--server-only --claude-dir …` ingests the
+> fixtures into your own `~/.lantern/cache.db` and forgets the projects that were in it. The cache is
+> disposable — one normal launch rebuilds it from `~/.claude` — but do not be surprised by an empty
+> board afterwards. Use `--cli-only` for fixture work, which does honour the flag.
 
 The board and `init` are built with React (Ink), so their sources are `.tsx` and Node cannot run them
 directly: `node src/server/main.ts` fails on the file extension as soon as it reaches for the board.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -22,12 +22,13 @@ The recommended loop is a build and run, not a dev server:
 
 ```bash
 pnpm build
-node dist/main.js --port 3400          # web UI
-node dist/main.js browse               # terminal board
+node dist/main.js --port 3400          # web UI and board together
+node dist/main.js --server-only        # web UI alone
+node dist/main.js --cli-only           # terminal board alone
 ```
 
 `pnpm dev` exists and runs both halves in parallel with `run-p` — Vite for the frontend on
-`DEV_FE_PORT` (3400), and `node --watch src/server/main.ts` for the backend on `DEV_BE_PORT` (3401),
+`DEV_FE_PORT` (3400), and `node --watch src/server/main.ts --server-only` for the backend on `DEV_BE_PORT` (3401),
 with `/api` proxied from the first to the second. It is fine for frontend work, but session process
 management shares memory between processes, so anything touching that needs verifying against a real
 build.
@@ -35,17 +36,18 @@ build.
 To work against the bundled fixtures instead of your own conversations:
 
 ```bash
-node dist/main.js browse --claude-dir ./fixtures/claude-home
-node dist/main.js --port 4100 --claude-dir ./fixtures/claude-home
+node dist/main.js --cli-only --claude-dir ./fixtures/claude-home
+node dist/main.js --server-only --port 4100 --claude-dir ./fixtures/claude-home
 ```
 
-The fixture conversations record invented working directories, so `lantern browse` will refuse to
-resume any of them — that refusal is correct behaviour, not a fault. Point it at your own history to
+The fixture conversations record invented working directories, so the board will refuse to resume
+any of them — that refusal is correct behaviour, not a fault. Point it at your own history to
 exercise resuming.
 
-`browse` and `init` are built with React (Ink), so their sources are `.tsx` and Node cannot run them
-directly: `node src/server/main.ts browse` fails on the file extension. Build first —
-`pnpm build:backend` is enough for both commands and takes about a second.
+The board and `init` are built with React (Ink), so their sources are `.tsx` and Node cannot run them
+directly: `node src/server/main.ts` fails on the file extension as soon as it reaches for the board.
+Build first — `pnpm build:backend` is enough and takes about a second. `--server-only` never loads
+Ink, so that one runs from source.
 
 ## The build
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ One npm package behind three front doors, all kept current by `lantern upgrade`:
 - **Docker** — ships its own
 
 Only the optional AI topic naming needs Claude Code installed and signed in. There is no setup step
-to run afterwards — `lantern browse` works straight out of the box.
+to run afterwards — `lantern` works straight out of the box.
 
 ## npm (any platform)
 
@@ -15,10 +15,10 @@ Needs Node.js 24 or newer already present:
 
 ```bash
 npm install -g lantern-viewer       # permanent, upgradeable with `lantern upgrade`
-lantern browse
+lantern
 
-npx lantern-viewer browse           # or run once, without installing
-npx lantern-viewer --port 3400
+npx lantern-viewer                  # or run once, without installing
+npx lantern-viewer --server-only --port 3400
 ```
 
 `pnpm`, `yarn` and `bun` work too; `lantern upgrade` uses whichever one put it there.
@@ -29,7 +29,7 @@ npx lantern-viewer --port 3400
 brew tap wildchildforlife/tap
 brew trust wildchildforlife/tap     # Homebrew gates third-party taps
 brew install lantern-viewer
-lantern browse                      # or: lantern --port 3400 for the web UI
+lantern                             # or: lantern --server-only --port 3400 for the web UI alone
 ```
 
 The formula is `lantern-viewer` — homebrew-cask already ships an unrelated `lantern` — but the
@@ -47,7 +47,7 @@ curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -   # or rpm.nod
 sudo apt install -y nodejs
 
 npm install -g lantern-viewer
-lantern browse
+lantern
 ```
 
 Or [linuxbrew](https://docs.brew.sh/Homebrew-on-Linux), which brings its own Node:
@@ -89,8 +89,9 @@ Lantern in **WSL2** as a Linux install and point `--claude-dir` at `/mnt/c/Users
 
 ## Docker
 
-For the web UI. `lantern browse` wants a terminal, which is not what a detached container has.
-Identical on macOS, Linux and Windows apart from the volume syntax.
+For the web UI. The board wants a terminal, which is not what a detached container has, so Lantern
+starts the server alone there without being told to. Identical on macOS, Linux and Windows apart from
+the volume syntax.
 
 ```bash
 docker run -d --name lantern \
@@ -142,8 +143,7 @@ See [dev.md](dev.md) if you intend to change anything.
 
 Everything works everywhere except the web UI's in-app terminal, which needs a prebuilt PTY binary
 that `@replit/ruspty` does not publish for every target. Where it is missing, Lantern disables the
-terminal and says so in its startup log; nothing else is affected, and `lantern browse` does not use
-it.
+terminal and says so in its startup log; nothing else is affected, and the board does not use it.
 
 | Platform                       | Supported | In-app terminal |
 | ------------------------------ | --------- | --------------- |

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -61,6 +61,10 @@ lantern --server-only --port 3400
 None of that applies to `lantern --cli-only` (or `lantern browse`), which opens no port and serves
 nothing.
 
+If you have run `lantern init` and told it to bind beyond `localhost`, that answer is stored, and a
+bare `lantern` now starts a server where `lantern browse` started none. Check `~/.lantern/config.json`
+before the first run of a version with this in it, or use `--cli-only` to open no port at all.
+
 The threat model, what a running instance exposes, and how to report a vulnerability privately are all
 in [SECURITY.md](../SECURITY.md). Binding and password options are in
 [Configuration](configuration.md#binding).

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -2,10 +2,20 @@
 
 `lantern` with no command starts a server and serves the same conversations as a web app, for the
 work a terminal is the wrong shape for — reading a long session back, searching message text, or
-picking through a cost breakdown.
+picking through a cost breakdown. It prints the address and then draws
+[the board](board.md) over it, so both are running from the one word; quitting the board stops the
+server too.
 
 ```bash
 lantern --port 3400
+```
+
+`--server-only` leaves the board out, which is what a container, a service file or anything else
+without a terminal wants. Lantern falls back to it on its own when there is no terminal to draw on,
+so a plain `lantern` still works unattended.
+
+```bash
+lantern --server-only --port 3400
 ```
 
 <p align="center">
@@ -48,7 +58,8 @@ lantern --port 3400
 > password, or keep it behind a VPN such as Tailscale. `--terminal-unrestricted` removes the guard
 > rails from bash sessions, so treat it as widening that same hole.
 
-None of that applies to `lantern browse`, which opens no port and serves nothing.
+None of that applies to `lantern --cli-only` (or `lantern browse`), which opens no port and serves
+nothing.
 
 The threat model, what a running instance exposes, and how to report a vulnerability privately are all
 in [SECURITY.md](../SECURITY.md). Binding and password options are in

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "run-p 'dev:*'",
     "dev:frontend": "vite",
-    "dev:backend": "LANTERN_ENV=development node --watch --env-file-if-exists=.env.local src/server/main.ts",
+    "dev:backend": "LANTERN_ENV=development node --watch --env-file-if-exists=.env.local src/server/main.ts --server-only",
     "start": "node dist/main.js",
     "build": "./scripts/build.sh",
     "build:frontend": "vite build",

--- a/src/cli/browse/browseCommand.tsx
+++ b/src/cli/browse/browseCommand.tsx
@@ -117,7 +117,7 @@ export const runBrowse = async (
   // beats the stack trace Ink would otherwise print.
   if (process.stdin.isTTY !== true) {
     process.stderr.write(
-      "lantern browse needs an interactive terminal. Run `lantern` for the web UI instead.\n",
+      "The Lantern board needs an interactive terminal. Run `lantern --server-only` for the web UI instead.\n",
     );
     return 1;
   }

--- a/src/cli/browse/launchBoard.ts
+++ b/src/cli/browse/launchBoard.ts
@@ -1,0 +1,20 @@
+import type { SharedCommandOptions } from "../commandOptions.ts";
+import type { CliConfig } from "../config/cliConfig.ts";
+
+/**
+ * Loads the terminal board and runs it, from either of the two commands that
+ * start one — a bare `lantern` and `lantern browse`.
+ *
+ * The import is deferred on purpose. Ink and React are a megabyte of bundle
+ * that `lantern --server-only`, `lantern init` and `lantern upgrade` have no
+ * use for, and keeping the one `import()` here is what stops a second caller
+ * pulling them in eagerly by accident.
+ */
+export const launchBoard = async (
+  options: SharedCommandOptions,
+  stored: CliConfig,
+): Promise<number> => {
+  const { runBrowse } = await import("./browseCommand.tsx");
+
+  return runBrowse(options, stored);
+};

--- a/src/cli/crash.test.ts
+++ b/src/cli/crash.test.ts
@@ -43,4 +43,19 @@ describe("describeCrash", () => {
     expect(describeCrash("just a string", false)).toContain("just a string");
     expect(describeCrash(undefined, false)).toContain("Lantern stopped unexpectedly");
   });
+
+  /** `String({})` is "[object Object]", which describes nothing. */
+  it("describes a thrown object by its shape rather than its type", () => {
+    const message = describeCrash({ code: "EACCES", path: "/root/.lantern" }, false);
+
+    expect(message).toContain("EACCES");
+    expect(message).not.toContain("[object Object]");
+  });
+
+  it("says only that it stopped when the thrown thing cannot be described", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(describeCrash(circular, false)).toContain("Lantern stopped unexpectedly");
+  });
 });

--- a/src/cli/crash.test.ts
+++ b/src/cli/crash.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { describeCrash } from "./crash.ts";
+
+describe("describeCrash", () => {
+  it("says what happened without the word `error`", () => {
+    const message = describeCrash(new Error("EADDRINUSE: address already in use"), false);
+
+    expect(message).not.toContain("Error");
+    expect(message).toContain("Lantern stopped unexpectedly");
+  });
+
+  it("keeps the one line that says what went wrong", () => {
+    expect(describeCrash(new Error("EADDRINUSE: address already in use"), false)).toContain(
+      "EADDRINUSE: address already in use",
+    );
+  });
+
+  it("says how to see more, and where to report it", () => {
+    const message = describeCrash(new Error("boom"), false);
+
+    expect(message).toContain("--verbose");
+    expect(message).toContain("github.com/WildChildForLife/lantern/issues");
+  });
+
+  /**
+   * The stack is the thing worth having in a bug report, and the thing nobody
+   * wants on screen by default. Asking for `--verbose` is asking for it.
+   */
+  it("holds the stack back until it is asked for", () => {
+    const error = new Error("boom");
+    error.stack = "Error: boom\n    at somewhere (file.ts:1:1)";
+
+    expect(describeCrash(error, false)).not.toContain("at somewhere");
+    expect(describeCrash(error, true)).toContain("at somewhere");
+  });
+
+  it("does not offer --verbose again to somebody who already passed it", () => {
+    expect(describeCrash(new Error("boom"), true)).not.toContain("Run the same command");
+  });
+
+  /** Anything can be thrown, and a string has no `message` to read. */
+  it("copes with something that is not an Error", () => {
+    expect(describeCrash("just a string", false)).toContain("just a string");
+    expect(describeCrash(undefined, false)).toContain("Lantern stopped unexpectedly");
+  });
+});

--- a/src/cli/crash.ts
+++ b/src/cli/crash.ts
@@ -1,0 +1,43 @@
+/** Where a crash is worth reporting, and the one link the message carries. */
+const ISSUES_URL = "https://github.com/WildChildForLife/lantern/issues";
+
+/**
+ * The one line that says what went wrong, from whatever was thrown.
+ *
+ * `String(error)` on an `Error` gives "Error: EADDRINUSE…", which puts the word
+ * back that the rest of this file exists to remove.
+ */
+const statement = (error: unknown): string | null => {
+  if (error instanceof Error) {
+    return error.message === "" ? null : error.message;
+  }
+
+  const text = String(error);
+
+  return text === "" || text === "undefined" || text === "null" ? null : text;
+};
+
+/**
+ * What to print when Lantern falls over, rather than the raw throw.
+ *
+ * An unexpected failure is the one place a stack trace is genuinely useful, and
+ * the one place it helps nobody by default: it is four lines of somebody else's
+ * bundle before the line that matters. So the message states the problem, and
+ * `--verbose` is what turns the stack on — which also makes "run it again with
+ * `--verbose`" the one instruction worth giving, because the output it produces
+ * is what a bug report needs.
+ */
+export const describeCrash = (error: unknown, verbose: boolean): string => {
+  const said = statement(error);
+  const stack = verbose && error instanceof Error ? error.stack : undefined;
+
+  return [
+    "Lantern stopped unexpectedly.",
+    ...(said === null ? [] : ["", `  ${said}`]),
+    ...(stack === undefined ? [] : ["", stack]),
+    "",
+    verbose
+      ? `Please report it at ${ISSUES_URL}`
+      : `Run the same command with --verbose to see more, and please report it at\n${ISSUES_URL}`,
+  ].join("\n");
+};

--- a/src/cli/crash.ts
+++ b/src/cli/crash.ts
@@ -12,9 +12,28 @@ const statement = (error: unknown): string | null => {
     return error.message === "" ? null : error.message;
   }
 
-  const text = String(error);
+  // Narrowed one type at a time rather than handed to `String`, which answers
+  // "[object Object]" for the case that most needs describing — and says so
+  // just as confidently as it reports a real message.
+  if (typeof error === "string") {
+    return error === "" ? null : error;
+  }
 
-  return text === "" || text === "undefined" || text === "null" ? null : text;
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
+    return error.toString();
+  }
+
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.stringify(error) ?? null;
+    } catch {
+      // Circular, or something that throws from its own `toJSON`. The heading
+      // above already says Lantern stopped; a placeholder adds nothing.
+      return null;
+    }
+  }
+
+  return null;
 };
 
 /**

--- a/src/cli/excessArguments.test.ts
+++ b/src/cli/excessArguments.test.ts
@@ -13,6 +13,11 @@ describe("describeExcessArguments", () => {
     expect(message).toContain("'orders-api'");
   });
 
+  /** Handing a command a word too many is a mistake, not an error. */
+  it("does not open by calling it an error", () => {
+    expect(describeExcessArguments(["orders-api"], "lantern browse")).not.toContain("error");
+  });
+
   it("names every stray word, not only the first", () => {
     const message = describeExcessArguments(["orders-api", "webhooks"], "lantern browse");
 

--- a/src/cli/excessArguments.ts
+++ b/src/cli/excessArguments.ts
@@ -20,7 +20,7 @@ export const describeExcessArguments = (
   const stray = given.map((word) => `'${word}'`).join(", ");
 
   return [
-    `error: \`${commandPath}\` takes no arguments, but got ${stray}.`,
+    `\`${commandPath}\` takes no arguments, but got ${stray}.`,
     "",
     `Run \`${commandPath} --help\` for the options it does take.`,
   ].join("\n");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { launchBoard } from "./browse/launchBoard.ts";
 import { parseSharedOptions } from "./commandOptions.ts";
 import { loadStoredOptions } from "./config/loadStoredOptions.ts";
 import { describeExcessArguments } from "./excessArguments.ts";
@@ -35,8 +36,8 @@ const rejectExcessArguments = (program: Command, command: Command): boolean => {
  * a terminal UI with React, but they drive the backend's Effect services
  * directly, so neither module boundary fits them.
  *
- * Both are loaded on demand. Ink and React are a megabyte of bundle that
- * `lantern` on its own has no use for, and the server's start-up time is the
+ * Each is loaded on demand. Ink and React are a megabyte of bundle that
+ * `lantern --server-only` has no use for, and the server's start-up time is the
  * one people wait on.
  */
 export const registerCliCommands = (program: Command): void => {
@@ -55,10 +56,13 @@ export const registerCliCommands = (program: Command): void => {
       process.exitCode = config === null ? 1 : 0;
     });
 
+  // Kept as its own name now that a bare `lantern` browses too: it is what
+  // every existing script, README and muscle memory types, and it is still the
+  // shortest way to ask for the board alone without reaching for a flag.
   program
     .command("browse")
     .alias("b")
-    .description("browse conversations by topic, without leaving the terminal")
+    .description("browse conversations by topic, without starting the web server")
     .option("--claude-dir <claude-dir>", "path to the claude directory to read")
     .option("-e, --executable <executable>", "path to the claude code executable")
     .option("-v, --verbose", "enable verbose debug logging")
@@ -73,12 +77,10 @@ export const registerCliCommands = (program: Command): void => {
         return;
       }
 
-      const { runBrowse } = await import("./browse/browseCommand.tsx");
-      const exitCode = await runBrowse(
+      process.exitCode = await launchBoard(
         parseSharedOptions(command.optsWithGlobals()),
         await loadStoredOptions(),
       );
-      process.exitCode = exitCode;
     });
 
   program

--- a/src/cli/init/initCommand.tsx
+++ b/src/cli/init/initCommand.tsx
@@ -50,7 +50,10 @@ const persist = (answers: WizardAnswers, existing: CliConfig) =>
  */
 export const runInit = async (options: SharedCommandOptions): Promise<CliConfig | null> => {
   if (process.stdin.isTTY !== true) {
-    process.stderr.write("lantern init needs an interactive terminal.\n");
+    process.stderr.write(
+      "`lantern init` asks questions, so it needs an interactive terminal.\n" +
+        "Every setting it writes has a working default, so Lantern runs without it.\n",
+    );
     return null;
   }
 

--- a/src/cli/parseProblem.test.ts
+++ b/src/cli/parseProblem.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { describeParseProblem } from "./parseProblem.ts";
+
+describe("describeParseProblem", () => {
+  it("drops the parser's `error:` prefix", () => {
+    const message = describeParseProblem("error: unknown option '--bogus'", "lantern");
+
+    expect(message).not.toContain("error");
+    expect(message).toContain("unknown option '--bogus'");
+  });
+
+  it("says where the options are listed", () => {
+    expect(describeParseProblem("error: unknown option '--bogus'", "lantern")).toContain(
+      "`lantern --help`",
+    );
+  });
+
+  it("names the command the problem came from, not always the program", () => {
+    expect(describeParseProblem("error: unknown option '--bogus'", "lantern upgrade")).toContain(
+      "`lantern upgrade --help`",
+    );
+  });
+
+  /**
+   * Commander adds its own suggestion after the message, on a second line. It
+   * is the most useful part, so it has to survive the rewrite.
+   */
+  it("keeps a suggestion the parser made", () => {
+    const message = describeParseProblem(
+      "error: unknown option '--verbse'\n(Did you mean --verbose?)",
+      "lantern",
+    );
+
+    expect(message).toContain("(Did you mean --verbose?)");
+  });
+
+  it("leaves a message that never said `error` alone", () => {
+    expect(
+      describeParseProblem("option '-p, --port <port>' argument missing", "lantern"),
+    ).toContain("option '-p, --port <port>' argument missing");
+  });
+
+  /** Commander writes a trailing newline; the caller adds its own. */
+  it("comes back without the trailing newline it was handed", () => {
+    expect(describeParseProblem("error: unknown option '--bogus'\n", "lantern")).not.toMatch(/\n$/);
+  });
+});

--- a/src/cli/parseProblem.ts
+++ b/src/cli/parseProblem.ts
@@ -1,0 +1,17 @@
+/**
+ * What to print when commander cannot make sense of the flags it was given.
+ *
+ * Commander's own text opens with `error:`, which is the one word Lantern never
+ * says to somebody who has simply mistyped a flag. The rest of the line is
+ * worth keeping exactly as it is — it names the flag, and commander sometimes
+ * follows it with a suggestion of its own, which is the most useful part of the
+ * whole message.
+ *
+ * `commandPath` is whichever command hit the problem, so the help it points at
+ * is the help that lists the flag that was missed.
+ */
+export const describeParseProblem = (raw: string, commandPath: string): string => {
+  const stated = raw.trimEnd().replace(/^error:\s*/u, "");
+
+  return [stated, "", `Run \`${commandPath} --help\` for the flags it takes.`].join("\n");
+};

--- a/src/cli/runMode.test.ts
+++ b/src/cli/runMode.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { describeRunModeConflict, resolveRunMode } from "./runMode.ts";
+
+describe("describeRunModeConflict", () => {
+  it("says what clashed without calling it an error", () => {
+    const message = describeRunModeConflict("lantern");
+
+    expect(message).not.toContain("error");
+    expect(message).toContain("--cli-only and --server-only ask for opposite things");
+  });
+
+  /** The reader wanted one of three things; all three are spelled out. */
+  it("shows every way of asking, so the reader can pick one", () => {
+    const message = describeRunModeConflict("lantern");
+
+    expect(message).toContain("lantern --cli-only");
+    expect(message).toContain("lantern --server-only");
+  });
+
+  it("uses the name the program was invoked under", () => {
+    expect(describeRunModeConflict("lantern-viewer")).toContain("lantern-viewer --cli-only");
+  });
+});
+
+describe("resolveRunMode", () => {
+  it("reports a conflict when both flags are given", () => {
+    expect(resolveRunMode({ cliOnly: true, serverOnly: true, interactive: true })).toBe("conflict");
+  });
+
+  it("reports a conflict even without a terminal", () => {
+    expect(resolveRunMode({ cliOnly: true, serverOnly: true, interactive: false })).toBe(
+      "conflict",
+    );
+  });
+
+  it("runs the board alone when --cli-only is given", () => {
+    expect(resolveRunMode({ cliOnly: true, serverOnly: false, interactive: true })).toBe("cli");
+  });
+
+  it("still asks for the board without a terminal, so the board can say why not", () => {
+    expect(resolveRunMode({ cliOnly: true, serverOnly: false, interactive: false })).toBe("cli");
+  });
+
+  it("runs the server alone when --server-only is given", () => {
+    expect(resolveRunMode({ cliOnly: false, serverOnly: true, interactive: true })).toBe("server");
+  });
+
+  it("runs both when neither flag is given at a terminal", () => {
+    expect(resolveRunMode({ cliOnly: false, serverOnly: false, interactive: true })).toBe("both");
+  });
+
+  it("falls back to the server alone when there is no terminal to draw on", () => {
+    expect(resolveRunMode({ cliOnly: false, serverOnly: false, interactive: false })).toBe(
+      "server",
+    );
+  });
+});

--- a/src/cli/runMode.ts
+++ b/src/cli/runMode.ts
@@ -10,7 +10,11 @@ export type RunMode = "both" | "cli" | "server" | "conflict";
 export type RunModeInput = {
   cliOnly: boolean;
   serverOnly: boolean;
-  /** Whether stdin is a terminal, which is the one thing the board needs. */
+  /**
+   * Whether there is a terminal on both stdin and stdout.
+   *
+   * Both, because the board reads keys from one and draws on the other.
+   */
   interactive: boolean;
 };
 

--- a/src/cli/runMode.ts
+++ b/src/cli/runMode.ts
@@ -1,0 +1,56 @@
+/**
+ * What a bare `lantern` should start.
+ *
+ * `both` is the default the command was renamed for: one word starts the web
+ * server and the terminal board together, and the two `--*-only` flags are how
+ * somebody asks for one half of that on its own.
+ */
+export type RunMode = "both" | "cli" | "server" | "conflict";
+
+export type RunModeInput = {
+  cliOnly: boolean;
+  serverOnly: boolean;
+  /** Whether stdin is a terminal, which is the one thing the board needs. */
+  interactive: boolean;
+};
+
+/**
+ * What `lantern --cli-only --server-only` is told.
+ *
+ * Both halves are printed rather than only the rule that was broken: somebody
+ * who reached for both flags knows what they want and has picked the wrong way
+ * to ask for it, so the useful reply is the three spellings, not a scolding.
+ */
+export const describeRunModeConflict = (programName: string): string =>
+  [
+    "--cli-only and --server-only ask for opposite things.",
+    "",
+    `  ${programName}                 both, together`,
+    `  ${programName} --cli-only      the board alone`,
+    `  ${programName} --server-only   the web UI alone`,
+  ].join("\n");
+
+/**
+ * Decides what a bare `lantern` runs, from the flags and the terminal it has.
+ *
+ * The two flags are answered before the terminal is, so `--cli-only` in a pipe
+ * still reaches the board and is turned away by it in those words — a fallback
+ * to the server there would silently start something nobody asked for. Only the
+ * default is allowed to fall back, because that is what a container, a service
+ * file or a CI job runs, and none of them have a screen to draw a board on.
+ */
+export const resolveRunMode = ({ cliOnly, serverOnly, interactive }: RunModeInput): RunMode => {
+  if (cliOnly && serverOnly) {
+    return "conflict";
+  }
+
+  if (cliOnly) {
+    return "cli";
+  }
+
+  if (serverOnly) {
+    return "server";
+  }
+
+  return interactive ? "both" : "server";
+};

--- a/src/cli/unknownCommand.test.ts
+++ b/src/cli/unknownCommand.test.ts
@@ -56,30 +56,35 @@ describe("describeUnknownCommand", () => {
   it("names what was typed, and what it probably meant", () => {
     const message = describeUnknownCommand(["brows"], known, "lantern");
 
-    expect(message).toContain("unknown command 'brows'");
+    expect(message).toContain("`lantern brows`");
     expect(message).toContain("`lantern browse`");
   });
 
   it("still lists the commands when it has nothing to suggest", () => {
     const message = describeUnknownCommand(["sessions"], known, "lantern");
 
-    expect(message).toContain("unknown command 'sessions'");
+    expect(message).toContain("`lantern sessions`");
     expect(message).not.toContain("Did you mean");
     expect(message).toContain("browse, init, upgrade");
   });
 
-  it("says how to start the web UI, which is the command that is not one", () => {
+  it("says what a plain `lantern` does, which is the command that is not one", () => {
     const message = describeUnknownCommand(["sessions"], known, "lantern");
 
     expect(message).toContain("`lantern` on its own");
     expect(message).toContain("`lantern --help`");
   });
 
+  /** A mistyped command is a typo, and Lantern never calls a typo an error. */
+  it("never opens by calling it an error", () => {
+    expect(describeUnknownCommand(["sessions"], known, "lantern")).not.toContain("error");
+  });
+
   /** Only the first word is the command; the rest were meant as its arguments. */
   it("reports the first word alone when several follow", () => {
     const message = describeUnknownCommand(["brows", "orders-api"], known, "lantern");
 
-    expect(message).toContain("unknown command 'brows'");
+    expect(message).toContain("`lantern brows`");
     expect(message).not.toContain("orders-api");
   });
 

--- a/src/cli/unknownCommand.ts
+++ b/src/cli/unknownCommand.ts
@@ -72,11 +72,12 @@ export const nearestCommand = (typed: string, known: readonly KnownCommand[]): s
 /**
  * What to print when the arguments name no command Lantern has.
  *
- * Commander's own answer is "too many arguments. Expected 0 arguments but got
- * 1", because a plain `lantern` starts the web UI and so the root command has
- * an action of its own: a mistyped subcommand arrives as one argument too many
- * rather than as an unknown command. That message describes the parser's
- * problem rather than the reader's, and never mentions the word it choked on.
+ * Commander's own answer is "error: too many arguments. Expected 0 arguments
+ * but got 1", because a plain `lantern` starts Lantern and so the root command
+ * has an action of its own: a mistyped subcommand arrives as one argument too
+ * many rather than as an unknown command. That message describes the parser's
+ * problem rather than the reader's, never mentions the word it choked on, and
+ * opens by calling a typo an error.
  *
  * Returns `null` when there is nothing to complain about, which is every launch
  * that meant to start the server.
@@ -100,13 +101,13 @@ export const describeUnknownCommand = (
 
   const opening =
     suggestion === null
-      ? `error: unknown command '${typed}'`
-      : `error: unknown command '${typed}'. Did you mean \`${programName} ${suggestion}\`?`;
+      ? `There is no \`${programName} ${typed}\` command.`
+      : `There is no \`${programName} ${typed}\` command. Did you mean \`${programName} ${suggestion}\`?`;
 
   return [
     opening,
     "",
-    `Commands: ${names}. \`${programName}\` on its own starts the web UI, and`,
-    `\`${programName} --help\` lists the options.`,
+    `Commands: ${names}. \`${programName}\` on its own starts the board with the web`,
+    `UI behind it, and \`${programName} --help\` lists the options.`,
   ].join("\n");
 };

--- a/src/server/lib/db/DrizzleService.ts
+++ b/src/server/lib/db/DrizzleService.ts
@@ -17,6 +17,12 @@ const initDbAtPath = (cacheDbPath: string): { db: DrizzleDb; rawDb: DatabaseSync
   const sqlite = new DatabaseSync(cacheDbPath);
   sqlite.exec("PRAGMA journal_mode = WAL");
   sqlite.exec("PRAGMA foreign_keys = ON");
+  // A bare `lantern` runs the server and the board in one process, and each
+  // opens its own connection to this file. WAL lets them read past each other,
+  // but two syncs that write at the same moment still collide — without a
+  // timeout the second one is refused outright rather than waiting the
+  // millisecond the first needs.
+  sqlite.exec("PRAGMA busy_timeout = 5000");
 
   const db = drizzle({ client: sqlite, schema });
   migrate(db, { migrationsFolder });

--- a/src/server/logging.test.ts
+++ b/src/server/logging.test.ts
@@ -13,4 +13,12 @@ describe("resolveLogLevel", () => {
   it("returns Info when verbose is undefined", () => {
     expect(resolveLogLevel(undefined).label).toBe("INFO");
   });
+
+  it("returns Warning when the server is sharing the screen with the board", () => {
+    expect(resolveLogLevel(undefined, true).label).toBe("WARN");
+  });
+
+  it("still returns Debug when verbose was asked for as well", () => {
+    expect(resolveLogLevel(true, true).label).toBe("DEBUG");
+  });
 });

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -1,11 +1,26 @@
 import { type Effect, LogLevel, Logger } from "effect";
 
-export const resolveLogLevel = (verbose: boolean | undefined) =>
-  verbose === true ? LogLevel.Debug : LogLevel.Info;
+/**
+ * How much the server says for itself.
+ *
+ * `quiet` is what a bare `lantern` uses, where the server and the terminal
+ * board share one process and one screen: every routine line the server would
+ * print lands on top of the board Ink is drawing. Warnings and errors still get
+ * through, because those are worth a corrupted frame; "Starting file watcher"
+ * is not. Asking for `--verbose` outranks it — somebody who wants the logs has
+ * said so.
+ */
+export const resolveLogLevel = (verbose: boolean | undefined, quiet?: boolean) => {
+  if (verbose === true) {
+    return LogLevel.Debug;
+  }
+
+  return quiet === true ? LogLevel.Warning : LogLevel.Info;
+};
 
 export const serverLoggerLayer = Logger.replace(Logger.defaultLogger, Logger.prettyLogger());
 
 export const withServerLogLevel =
-  (verbose: boolean | undefined) =>
+  (verbose: boolean | undefined, quiet?: boolean) =>
   <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    effect.pipe(Logger.withMinimumLogLevel(resolveLogLevel(verbose)));
+    effect.pipe(Logger.withMinimumLogLevel(resolveLogLevel(verbose, quiet)));

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import packageJson from "../../package.json" with { type: "json" };
+import { launchBoard } from "../cli/browse/launchBoard.ts";
+import { parseSharedOptions } from "../cli/commandOptions.ts";
+import { loadStoredOptions } from "../cli/config/loadStoredOptions.ts";
+import { describeCrash } from "../cli/crash.ts";
 import { maybeRunFirstRunWizard } from "../cli/firstRunWizard.ts";
 import { registerCliCommands } from "../cli/index.ts";
+import { describeParseProblem } from "../cli/parseProblem.ts";
+import { describeRunModeConflict, resolveRunMode } from "../cli/runMode.ts";
 import { describeUnknownCommand } from "../cli/unknownCommand.ts";
 import { maybeNotifyUpdate } from "../cli/update/notifyUpdate.ts";
 import type { CliOptions } from "./core/platform/services/LanternOptionsService.ts";
 import { checkNodeVersion } from "./nodeVersionCheck.ts";
-import { startServer } from "./startServer.ts";
+import { startServer, stopServer } from "./startServer.ts";
 
 checkNodeVersion();
 
@@ -20,8 +26,20 @@ const [commandName = packageJson.name] = Object.keys(packageJson.bin);
 
 program.name(commandName).version(packageJson.version).description(packageJson.description);
 
-// start server
+// Commander opens every complaint of its own with `error:` — an unknown flag, a
+// flag whose value is missing. Rewriting them here catches all of them at once,
+// including the ones no code of Lantern's ever sees, and the subcommands
+// registered below inherit this along with the rest of the root's settings.
+program.configureOutput({
+  outputError: (text, write) => {
+    write(`${describeParseProblem(text, program.name())}\n`);
+  },
+});
+
+// Start the web server and the terminal board together — see `resolveRunMode`.
 program
+  .option("--cli-only", "only browse in the terminal, without starting the web server")
+  .option("--server-only", "only start the web server, without the terminal board")
   .option("-p, --port <port>", "port to listen on")
   .option("-h, --hostname <hostname>", "hostname to listen on")
   .option("-v, --verbose", "enable verbose debug logging")
@@ -42,28 +60,89 @@ program
   // many, in those words. Taking the arguments instead lets the action say
   // which word it did not know — see `describeUnknownCommand`.
   .allowExcessArguments()
-  .action(async (options: CliOptions & { init?: boolean }, command: Command) => {
-    const unknown = describeUnknownCommand(
-      command.args,
-      command.commands.map((sub) => ({ name: sub.name(), aliases: sub.aliases() })),
-      command.name(),
-    );
+  .action(
+    async (
+      options: CliOptions & { init?: boolean; cliOnly?: boolean; serverOnly?: boolean },
+      command: Command,
+    ) => {
+      const unknown = describeUnknownCommand(
+        command.args,
+        command.commands.map((sub) => ({ name: sub.name(), aliases: sub.aliases() })),
+        command.name(),
+      );
 
-    if (unknown !== null) {
-      process.stderr.write(`${unknown}\n`);
-      process.exitCode = 1;
-      return;
-    }
+      if (unknown !== null) {
+        process.stderr.write(`${unknown}\n`);
+        process.exitCode = 1;
+        return;
+      }
 
-    // A first launch at a terminal walks through setup, then carries straight
-    // on into starting the server with the answers. Anything without a
-    // terminal — a container, CI, a pipe — skips it silently.
-    const stored = await maybeRunFirstRunWizard(options.claudeDir, options.init !== false);
+      const mode = resolveRunMode({
+        cliOnly: options.cliOnly === true,
+        serverOnly: options.serverOnly === true,
+        // Both halves, because the board draws on one and reads keys from the
+        // other. `lantern | tee` has a terminal to read from and nowhere to
+        // draw, and it has always started a server rather than a board.
+        interactive: process.stdin.isTTY === true && process.stdout.isTTY === true,
+      });
 
-    await startServer(options, stored);
-  });
+      if (mode === "conflict") {
+        process.stderr.write(`${describeRunModeConflict(command.name())}\n`);
+        process.exitCode = 1;
+        return;
+      }
+
+      // The board alone is the one route that does not offer setup, exactly as
+      // `lantern browse` never has: every question the wizard asks is about a
+      // server this run is not going to start, and the board's own settings all
+      // have a working default.
+      if (mode === "cli") {
+        process.exitCode = await launchBoard(
+          parseSharedOptions(options),
+          await loadStoredOptions(),
+        );
+        return;
+      }
+
+      // A first launch at a terminal walks through setup, then carries straight
+      // on into starting the server with the answers. Anything without a
+      // terminal — a container, CI, a pipe — skips it silently.
+      const stored = await maybeRunFirstRunWizard(options.claudeDir, options.init !== false);
+
+      if (mode === "server") {
+        await startServer(options, stored);
+        return;
+      }
+
+      // Both. The server's own start-up line is silenced — the board is about
+      // to draw over the row it would land on — so the address is printed here
+      // instead, once, into the scrollback the board hands back on the way out.
+      const { server, url } = await startServer(options, stored, { quiet: true });
+      process.stderr.write(`Web UI: ${url}\n`);
+
+      const exitCode = await launchBoard(parseSharedOptions(options), stored);
+
+      // Quitting the board quits Lantern: one command started both halves, so
+      // one keypress stops both. The exit is explicit because closing the port
+      // is not enough on its own — the file watchers and the cache connection
+      // the server opened would keep the process alive with nothing left to do.
+      await stopServer(server);
+      process.exit(exitCode);
+    },
+  );
 
 registerCliCommands(program);
+
+// Each subcommand points at its own help rather than the program's, because the
+// flag that was mistyped is one of theirs. Done here, over the finished list,
+// so registering a command is never also a job of remembering to do this.
+for (const subcommand of program.commands) {
+  subcommand.configureOutput({
+    outputError: (text, write) => {
+      write(`${describeParseProblem(text, `${program.name()} ${subcommand.name()}`)}\n`);
+    },
+  });
+}
 
 const main = async () => {
   // Before the command runs, so the line lands in the scrollback rather than
@@ -85,6 +164,11 @@ const main = async () => {
 };
 
 main().catch((error: unknown) => {
-  process.stderr.write(`${String(error)}\n`);
+  // Read from argv rather than the parsed options: whatever threw may well have
+  // thrown before there were any, and this is the one message that has to work
+  // no matter how early things went wrong.
+  const verbose = process.argv.includes("--verbose") || process.argv.includes("-v");
+
+  process.stderr.write(`${describeCrash(error, verbose)}\n`);
   process.exit(1);
 });

--- a/src/server/nodeVersionCheck.test.ts
+++ b/src/server/nodeVersionCheck.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { describeOutdatedNode } from "./nodeVersionCheck.ts";
+
+describe("describeOutdatedNode", () => {
+  it("has nothing to say about a version new enough to run on", () => {
+    expect(describeOutdatedNode("v24.0.0")).toBe(null);
+    expect(describeOutdatedNode("v25.1.2")).toBe(null);
+  });
+
+  it("says what is needed and what is here, without the word `error`", () => {
+    const message = describeOutdatedNode("v22.22.0");
+
+    expect(message).not.toContain("Error");
+    expect(message).toContain("Node.js 24");
+    expect(message).toContain("v22.22.0");
+  });
+
+  /**
+   * The reader's next move is installing one, and the answer differs by how
+   * they got Node in the first place — so both routes are printed.
+   */
+  it("offers a way out rather than only a requirement", () => {
+    const message = describeOutdatedNode("v20.0.0");
+
+    expect(message).toContain("nvm");
+    expect(message).toContain("nodejs.org");
+  });
+
+  /** `process.version` is always prefixed, but nothing here should depend on it. */
+  it("reads a version with or without the leading v", () => {
+    expect(describeOutdatedNode("22.22.0")).toContain("22.22.0");
+    expect(describeOutdatedNode("24.0.0")).toBe(null);
+  });
+
+  /** An unreadable version is not a reason to refuse to start. */
+  it("says nothing about a version it cannot read", () => {
+    expect(describeOutdatedNode("not-a-version")).toBe(null);
+  });
+});

--- a/src/server/nodeVersionCheck.ts
+++ b/src/server/nodeVersionCheck.ts
@@ -1,20 +1,54 @@
 /**
- * Checks that the current Node.js version satisfies the minimum requirement.
+ * The oldest Node Lantern runs on.
  *
- * drizzle-orm's node-sqlite adapter uses StatementSync.setReturnArrays(),
- * which is only available in Node.js >=24.0.0.
+ * drizzle-orm's node-sqlite adapter uses StatementSync.setReturnArrays(), which
+ * is only available in Node.js >=24.0.0.
  *
  * @see https://nodejs.org/api/sqlite.html#statementsetreturnarraysenabled
  */
-export const checkNodeVersion = (): void => {
-  const majorStr = process.version.slice(1).split(".")[0];
-  const major = Number(majorStr);
+const MINIMUM_MAJOR = 24;
 
-  if (major < 24) {
-    process.stderr.write(
-      `Error: Lantern requires Node.js >=24.0.0, but you are running ${process.version}.\n` +
-        `Please upgrade your Node.js version.\n`,
-    );
-    process.exit(1);
+/**
+ * What to print when Node is too old to run on, or `null` when it is not.
+ *
+ * The version alone is a requirement, not an answer — somebody reading this has
+ * a Node they did not choose on purpose, usually the one their distribution or
+ * their `nvm` default gave them. Both ways out are printed because which one
+ * applies depends on how they got the Node they have.
+ */
+export const describeOutdatedNode = (version: string): string | null => {
+  const major = Number.parseInt(version.replace(/^v/u, ""), 10);
+
+  if (Number.isNaN(major) || major >= MINIMUM_MAJOR) {
+    return null;
   }
+
+  // Padded rather than spaced by hand: the left-hand column is built from
+  // MINIMUM_MAJOR, so its width changes the day that constant does.
+  const routes: readonly (readonly [string, string])[] = [
+    [`nvm install ${MINIMUM_MAJOR} && nvm use ${MINIMUM_MAJOR}`, "if you use nvm"],
+    ["https://nodejs.org/en/download", "to install it yourself"],
+  ];
+  const column = Math.max(...routes.map(([command]) => command.length));
+
+  return [
+    `Lantern needs Node.js ${MINIMUM_MAJOR} or newer, and this one is ${version}.`,
+    "",
+    ...routes.map(([command, when]) => `  ${command.padEnd(column)}   ${when}`),
+    "",
+    "Homebrew's lantern-viewer brings its own Node, if you would rather not keep",
+    "one up to date yourself.",
+  ].join("\n");
+};
+
+/** Stops before anything else runs when the Node underneath cannot run it. */
+export const checkNodeVersion = (): void => {
+  const problem = describeOutdatedNode(process.version);
+
+  if (problem === null) {
+    return;
+  }
+
+  process.stderr.write(`${problem}\n`);
+  process.exit(1);
 };

--- a/src/server/startServer.test.ts
+++ b/src/server/startServer.test.ts
@@ -1,0 +1,76 @@
+// A bare Node HTTP server rather than Lantern's own: what this checks is how
+// `stopServer` behaves against Node's `close` semantics, so the server under it
+// has to be the plain one those semantics belong to.
+import { createServer, get, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { stopServer } from "./startServer.ts";
+
+const listening = (server: Server): Promise<number> =>
+  new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve(typeof address === "object" && address !== null ? address.port : 0);
+    });
+  });
+
+/**
+ * A request the server answers and then holds open, the way `/api/sse` does.
+ *
+ * Resolves once the response has started, so the connection is established and
+ * unfinished by the time the test asks the server to stop.
+ */
+const openStream = (port: number): Promise<void> =>
+  new Promise((resolve) => {
+    get({ host: "127.0.0.1", port, path: "/" }, () => {
+      resolve();
+    });
+  });
+
+const opened: Server[] = [];
+
+const serverHoldingConnectionsOpen = (): Server => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.write(": open\n\n");
+  });
+
+  opened.push(server);
+
+  return server;
+};
+
+afterEach(() => {
+  for (const server of opened.splice(0)) {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+describe("stopServer", () => {
+  it("stops a server that nothing is talking to", async () => {
+    const server = serverHoldingConnectionsOpen();
+    await listening(server);
+
+    await stopServer(server);
+
+    expect(server.listening).toBe(false);
+  });
+
+  /**
+   * The regression this exists for.
+   *
+   * `close` alone waits for every open connection to end, and the two this
+   * server holds longest — an SSE stream and a terminal WebSocket — never end
+   * on their own. A bare `lantern` awaits this before it exits, so a browser
+   * tab left open on the web UI used to mean `q` never gave the terminal back.
+   */
+  it("stops a server with a stream still open, rather than waiting for it", async () => {
+    const server = serverHoldingConnectionsOpen();
+    const port = await listening(server);
+    await openStream(port);
+
+    await stopServer(server);
+
+    expect(server.listening).toBe(false);
+  });
+});

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -1,6 +1,6 @@
 import { FileSystem, Path } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { createAdaptorServer } from "@hono/node-server";
+import { createAdaptorServer, type ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Effect, Layer } from "effect";
 import { AgentSessionLayer } from "./core/agent-session/index.ts";
@@ -62,14 +62,43 @@ import { platformLayer } from "./lib/effect/layers.ts";
 import { serverLoggerLayer, withServerLogLevel } from "./logging.ts";
 import { setupTerminalWebSocket } from "./terminal/terminalWebSocket.ts";
 
-export const startServer = async (options: CliOptions, stored?: StoredOptions) => {
+export type StartServerOptions = {
+  /**
+   * Whether something else owns the screen — see `resolveLogLevel`.
+   *
+   * Set by the bare `lantern`, which runs the terminal board in this same
+   * process the moment the server is up.
+   */
+  quiet?: boolean;
+};
+
+export type StartedServer = {
+  server: ServerType;
+  /** Where the server can be reached, port included, ready to print or open. */
+  url: string;
+};
+
+/**
+ * Starts the web server, and hands back the server it started.
+ *
+ * Resolves once the port is actually bound rather than once `listen` has been
+ * called, so a caller can print the URL — or draw a board over it — knowing the
+ * server behind it is answering. The returned server is what closes it again:
+ * a bare `lantern` shuts it down when the board quits.
+ */
+export const startServer = async (
+  options: CliOptions,
+  stored?: StoredOptions,
+  serverOptions?: StartServerOptions,
+): Promise<StartedServer> => {
   // Resolved once, here, so the port and bind address the server listens on and
   // the ones every service reads come from the same precedence rules.
   const resolved = toLanternOptions(options, stored);
+  const quiet = serverOptions?.quiet === true;
 
   const runWithLogger = <A, E>(effect: Effect.Effect<A, E, never>) =>
     Effect.runPromise(
-      effect.pipe(withServerLogLevel(resolved.verbose), Effect.provide(serverLoggerLayer)),
+      effect.pipe(withServerLogLevel(resolved.verbose, quiet), Effect.provide(serverLoggerLayer)),
     );
 
   // biome-ignore lint/style/noProcessEnv: allow only here
@@ -122,7 +151,11 @@ export const startServer = async (options: CliOptions, stored?: StoredOptions) =
     // Layers must be piped into the container from the shallowest dependency up
     .pipe(Effect.provide(MainLayer), Effect.scoped);
 
-  await Effect.runPromise(program);
+  // The level is set around the whole program, not only the two lines below:
+  // the background fibers the layers fork — the sync, the file watcher — copy
+  // it as they are forked, and they are the ones that would otherwise write
+  // over the board long after start-up is done.
+  await Effect.runPromise(program.pipe(withServerLogLevel(resolved.verbose, quiet)));
 
   const port = isDevelopment
     ? // biome-ignore lint/style/noProcessEnv: allow only here
@@ -130,15 +163,27 @@ export const startServer = async (options: CliOptions, stored?: StoredOptions) =
       Number.parseInt(process.env.DEV_BE_PORT ?? "3401", 10)
     : resolved.port;
 
-  server.listen(port, resolved.hostname, () => {
-    const info = server.address();
-    const serverPort = typeof info === "object" && info !== null ? info.port : port;
-    const mode = apiOnly ? " (API-only mode)" : "";
-    void runWithLogger(
-      Effect.logInfo(`Server is running on http://${resolved.hostname}:${serverPort}${mode}`),
-    );
+  const url = await new Promise<string>((resolve) => {
+    server.listen(port, resolved.hostname, () => {
+      const info = server.address();
+      const serverPort = typeof info === "object" && info !== null ? info.port : port;
+      const mode = apiOnly ? " (API-only mode)" : "";
+      const address = `http://${resolved.hostname}:${serverPort}`;
+      void runWithLogger(Effect.logInfo(`Server is running on ${address}${mode}`));
+      resolve(address);
+    });
   });
+
+  return { server, url };
 };
+
+/** Stops a server started by `startServer`, and waits for it to be stopped. */
+export const stopServer = (server: ServerType): Promise<void> =>
+  new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
 
 const PlatformLayer = Layer.mergeAll(platformLayer, NodeContext.layer);
 

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -177,12 +177,28 @@ export const startServer = async (
   return { server, url };
 };
 
-/** Stops a server started by `startServer`, and waits for it to be stopped. */
+/**
+ * Stops a server started by `startServer`, and waits for it to be stopped.
+ *
+ * `close` on its own only stops new connections arriving: it waits for every
+ * open one to end first, and the two this server holds longest never end on
+ * their own — an SSE stream stays open for as long as the page is, and so does
+ * a terminal WebSocket. A bare `lantern` waits on this before it exits, so
+ * without dropping those connections a browser tab left open on the web UI
+ * means `q` never gives the terminal back.
+ *
+ * Narrowed rather than cast: `ServerType` is a union, and `closeAllConnections`
+ * belongs to the HTTP/1 server that `createAdaptorServer` actually returns.
+ */
 export const stopServer = (server: ServerType): Promise<void> =>
   new Promise<void>((resolve) => {
     server.close(() => {
       resolve();
     });
+
+    if ("closeAllConnections" in server) {
+      server.closeAllConnections();
+    }
   });
 
 const PlatformLayer = Layer.mergeAll(platformLayer, NodeContext.layer);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath, URL } from "node:url";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 const config = defineConfig({
   resolve: {
@@ -9,6 +9,10 @@ const config = defineConfig({
   },
   test: {
     globals: true,
+    // Vitest does not read .gitignore, so ignoring the harness's worktrees
+    // there is not enough on its own to keep a second copy of the tree out of
+    // the run.
+    exclude: [...configDefaults.exclude, ".claude/**"],
     setupFiles: ["src/testing/setup/vitest.setup.ts"],
     env: {
       ENVIRONMENT: "local",


### PR DESCRIPTION
Typing `lantern` started the web server and nothing else, so reaching the board meant remembering a second word. It now starts the server, prints its address, and draws the board over it. Quitting the board stops both.

Along the way, every message the CLI printed at a mistake opened with `error:` or `Error:`, and an unexpected failure printed the raw throw. Those are rewritten as plain guidance.

## What changes

```
lantern                    the board, with the web UI behind it
lantern --cli-only         the board alone, opening no port
lantern --server-only      the web UI alone
lantern browse             unchanged, and the same as --cli-only
```

Passing both flags is refused rather than guessed at. With no terminal to draw on — a container, a pipe, CI — Lantern starts the server alone without being told to, so an unattended `lantern` keeps working. `pnpm dev` and the Docker docs are pinned to `--server-only` for the same reason.

Server logs are held back to warnings while the board owns the screen, since the lines it prints at startup would otherwise land on top of it. `--verbose` still turns them all on. The level is applied around the whole program rather than the two lines that log directly, so the background fibers the layers fork — the sync, the file watcher — inherit it as they are forked.

Combined mode opens two SQLite connections to the same cache, one per half, so `PRAGMA busy_timeout` is set: WAL lets them read past each other, but two syncs that write at the same moment would otherwise see the second refused outright rather than waiting the millisecond the first needs.

## The messages

| Before | After |
| --- | --- |
| `error: unknown command 'brwose'. Did you mean ...` | ``There is no `lantern brwose` command. Did you mean `lantern browse`?`` |
| ``error: `lantern browse` takes no arguments`` | ``` `lantern browse` takes no arguments, but got 'orders-api'. ``` |
| `error: unknown option '--bogus'` | `unknown option '--bogus'` + where the flags are listed |
| `Error: Lantern requires Node.js >=24.0.0` | what is needed, what is here, and two ways to install it |
| `(FiberFailure) SystemError: NotFound: ...` | what went wrong, and `--verbose` for the stack |

Commander's own output is rewritten through `configureOutput`, so the messages no code of Lantern's ever sees are covered too, and each subcommand points at its own help rather than the program's.

Exit codes are unchanged. A run that did not do what was asked still exits non-zero, so scripts and service files can still tell.

## Fixed after review

**Quitting the board could hang.** `stopServer` awaited `server.close()`, which stops new connections arriving but waits for every open one to end — and the two this server holds longest never end on their own: an SSE stream for as long as the page is open, a terminal WebSocket for as long as the session is. Opening the web UI in a browser and then pressing `q` left the terminal wedged until Ctrl-C, which is exactly the flow this PR invites.

Reproduced against the built binary before the fix, with a control to rule out "`q` was never delivered":

| Run | SSE client attached | On `q` |
| --- | --- | --- |
| control | no | exits, rc=0 |
| repro | yes | still running after 12s |
| after fix | yes | exits, rc=0 |

Connections are now dropped as well as the port closed, narrowed with `in` rather than cast because `ServerType` is a union. `src/server/startServer.test.ts` covers a server with a stream still open, and fails without the fix.

Also from the review:

- The security note in the README and `docs/web-ui.md` now says that an address stored by `lantern init` is what a bare `lantern` binds. Somebody who set `0.0.0.0` for the web UI and then lived in `lantern browse` was about to open a terminal-enabled port where none opened before.
- The README no longer claims a bare `lantern` opens no port, no longer calls a refused flag combination an error, and its quick start no longer says `browse`.
- `describeCrash` narrows what was thrown instead of handing it to `String`, which answered `[object Object]` for the case that most needed describing.
- `RunModeInput.interactive` now documents what the call site actually checks — a terminal on both stdin and stdout, not just stdin.

## Found while reviewing, not fixed here

`--claude-dir` moves the **board's** cache but not the **server's**. The server builds its database layer before it has read the flag, so `--server-only --claude-dir …` ingests whatever that directory holds into your own `~/.lantern/cache.db` and forgets the projects that were in it — which is what `src/cli/platformLayer.ts` already describes working around on the CLI side. This predates the PR and the fix is a layer-construction change well outside its scope, so `docs/dev.md` carries a warning and it is worth its own issue. `--cli-only` honours the flag correctly.

The knock-on is that combined mode with `--claude-dir` keeps two caches and syncs twice. Without the flag both halves share `~/.lantern`, the board finds it warm, and only the server syncs — measured, not assumed.

## Checks

`pnpm gatecheck check` clean. Full suite 189 files / 1803 tests passing, on Node 22 and Node 24. `./scripts/lingui-check.sh` clean.

New pure functions are covered: mode resolution from flags and TTY, the conflict message, the crash message, the Node version message, and the parser rewrite. Each message module also asserts its output never contains the word "error", so this does not quietly regress. `stopServer` is covered against a live connection.

Beyond that, the built binary was run against every path: the flag conflict, an unknown flag on the root and on a subcommand, a mistyped command, a stray argument, a missing flag value, an old Node, and a real crash. Combined mode was driven over a pty — server bound, address printed, alternate screen entered, board drawn from the fixtures with server logs silenced — plus the non-TTY fallback answering HTTP 200, `--cli-only` refusing a pipe, and the SSE quit case above.

## Note for review

`lantern` is a breaking change for anyone scripting the bare command and expecting only a server; `--server-only` is the replacement, and the no-TTY fallback means most unattended uses need no edit at all.