### PR TITLE
feat: open the terminal board against an already-running Lantern

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -73,3 +73,14 @@ in [SECURITY.md](../SECURITY.md). Binding and password options are in
 
 Lantern binds `127.0.0.1:3000` by default. See [Configuration](configuration.md) for the full options
 table, how a setting is resolved, and why the bind address is not read from `HOSTNAME`.
+
+## More than one terminal
+
+One web server serves them all. A second `lantern` sees the one already listening, opens its board
+against it and starts no server of its own — so you can run as many as you have terminals, and
+quitting one leaves the rest alone. The board reads the cache directly rather than over HTTP, so it
+loses nothing by not having a server behind it.
+
+`lantern --server-only` is the exception: it asked for a server, has no board to fall back to, and
+says so rather than starting a second one. Pass `--port` if a genuinely separate web UI is what you
+want.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -77,10 +77,13 @@ table, how a setting is resolved, and why the bind address is not read from `HOS
 ## More than one terminal
 
 One web server serves them all. A second `lantern` sees the one already listening, opens its board
-against it and starts no server of its own — so you can run as many as you have terminals, and
-quitting one leaves the rest alone. The board reads the cache directly rather than over HTTP, so it
-loses nothing by not having a server behind it.
+against it and starts no server of its own, so you can run as many as you have terminals. The board
+reads the cache directly rather than over HTTP, so it loses nothing by not having a server behind it.
 
-`lantern --server-only` is the exception: it asked for a server, has no board to fall back to, and
-says so rather than starting a second one. Pass `--port` if a genuinely separate web UI is what you
-want.
+The web server belongs to the terminal that started it. Quitting an attached board leaves everything
+else running; quitting the first one takes the web UI down, and the boards still open carry on
+browsing without it.
+
+`lantern --server-only` is the exception to attaching: it asked for a server, has no board to fall
+back to, and says so rather than starting a second one. Pass `--port` if a genuinely separate web UI
+is what you want.

--- a/src/cli/config/cliConfigStore.test.ts
+++ b/src/cli/config/cliConfigStore.test.ts
@@ -137,6 +137,58 @@ describe("cliConfigStore", () => {
     ),
   );
 
+  /**
+   * The case that used to pass for a first launch on every single launch: the
+   * file is there, `exists` says so, and opening it fails. Their settings are
+   * gone and nothing said a word.
+   */
+  it.live("reports a file that is there and will not open", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        // A directory where the file belongs: it exists, and it cannot be read.
+        yield* fs.makeDirectory(path.join(baseDir, "config.json"));
+
+        const result = yield* readCliConfigResult.pipe(Effect.provide(withBaseDir(baseDir)));
+
+        expect(result.unreadable).toBe(true);
+        expect(result.config).toStrictEqual(defaultCliConfig);
+      }),
+    ),
+  );
+
+  /** An interrupted write, or a bare `touch`. Nothing was lost. */
+  it.live("does not call an empty file unreadable", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        yield* fs.writeFileString(path.join(baseDir, "config.json"), "\n  \n");
+
+        const result = yield* readCliConfigResult.pipe(Effect.provide(withBaseDir(baseDir)));
+
+        expect(result.unreadable).toBe(false);
+        expect(result.config).toStrictEqual(defaultCliConfig);
+      }),
+    ),
+  );
+
+  /** Valid JSON that the schema turns away is just as lost as broken JSON. */
+  it.live("reports a file whose settings do not fit the schema", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        yield* fs.writeFileString(path.join(baseDir, "config.json"), `{"port":70000}`);
+
+        const result = yield* readCliConfigResult.pipe(Effect.provide(withBaseDir(baseDir)));
+
+        expect(result.unreadable).toBe(true);
+      }),
+    ),
+  );
+
   it.live("does not call a file it understood unreadable", () =>
     withTempBaseDir((baseDir) =>
       Effect.gen(function* () {

--- a/src/cli/config/cliConfigStore.test.ts
+++ b/src/cli/config/cliConfigStore.test.ts
@@ -8,6 +8,7 @@ import {
   CliConfigBaseDir,
   cliConfigExists,
   readCliConfig,
+  readCliConfigResult,
   writeCliConfig,
 } from "./cliConfigStore.ts";
 
@@ -103,6 +104,50 @@ describe("cliConfigStore", () => {
         expect(yield* readCliConfig.pipe(Effect.provide(withBaseDir(baseDir)))).toStrictEqual(
           defaultCliConfig,
         );
+      }),
+    ),
+  );
+
+  /** What tells `loadStoredOptions` there is something worth mentioning. */
+  it.live("reports an unreadable file, and where it is", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const configPath = path.join(baseDir, "config.json");
+        yield* fs.writeFileString(configPath, "{ not json");
+
+        const result = yield* readCliConfigResult.pipe(Effect.provide(withBaseDir(baseDir)));
+
+        expect(result.unreadable).toBe(true);
+        expect(result.configPath).toBe(configPath);
+        expect(result.config).toStrictEqual(defaultCliConfig);
+      }),
+    ),
+  );
+
+  /** A first launch has no file, which is not a problem to report. */
+  it.live("does not call a missing file unreadable", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        const result = yield* readCliConfigResult.pipe(Effect.provide(withBaseDir(baseDir)));
+
+        expect(result.unreadable).toBe(false);
+      }),
+    ),
+  );
+
+  it.live("does not call a file it understood unreadable", () =>
+    withTempBaseDir((baseDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        yield* fs.writeFileString(path.join(baseDir, "config.json"), `{"port":3400}`);
+
+        const result = yield* readCliConfigResult.pipe(Effect.provide(withBaseDir(baseDir)));
+
+        expect(result.unreadable).toBe(false);
+        expect(result.config.port).toBe(3400);
       }),
     ),
   );

--- a/src/cli/config/cliConfigStore.ts
+++ b/src/cli/config/cliConfigStore.ts
@@ -43,18 +43,24 @@ export const cliConfigExists = Effect.gen(function* () {
   return yield* fs.exists(configPath).pipe(Effect.catchAll(() => Effect.succeed(false)));
 });
 
-/** What a read found, for the one caller that has somebody to tell about it. */
+/** What a read found, for the callers that have somebody to tell about it. */
 export type CliConfigResult = {
-  config: CliConfig;
+  readonly config: CliConfig;
   /** Where the settings live, whether or not this read got anything from it. */
-  configPath: string;
+  readonly configPath: string;
   /**
-   * Whether a file was there and could not be understood.
+   * Whether a file was there and this read got nothing usable out of it.
+   *
+   * True for a file that cannot be opened as much as for one that cannot be
+   * parsed: from the reader's side those are the same loss, and permissions are
+   * the likelier of the two to happen by accident.
    *
    * A missing file is not unreadable — that is a first launch, and the defaults
-   * are the right answer rather than a thing worth mentioning.
+   * are the right answer rather than a thing worth mentioning. Neither is an
+   * empty one, which is what an interrupted write leaves behind and what a
+   * fresh `touch` makes.
    */
-  unreadable: boolean;
+  readonly unreadable: boolean;
 };
 
 /**
@@ -63,10 +69,10 @@ export type CliConfigResult = {
  * This runs before anything else on every launch, so a file somebody edited by
  * hand must cost them their preferences and nothing more.
  *
- * Nothing is printed from here. The file is opened two or three times on a
- * single launch and each read would be entitled to complain about the same
- * file, so the reporting belongs to the caller that has a reader in front of it
- * — see `loadStoredOptions`.
+ * Nothing is printed from here. `loadStoredOptions` can run more than once in a
+ * launch — the wizard reads the file, and a cancelled wizard is followed by
+ * another read — so the reporting belongs to the caller that has a reader in
+ * front of it and can say a thing once.
  */
 export const readCliConfigResult = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -77,10 +83,20 @@ export const readCliConfigResult = Effect.gen(function* () {
     return fallback;
   }
 
+  // `null` rather than `""` for a failed read, because the two are different
+  // answers: an empty file is a file with no settings in it, and a file that
+  // will not open is settings that have been lost. Folding them together is
+  // what let a permission problem pass for a first launch, silently, on every
+  // launch after it.
   const content = yield* fs
     .readFileString(configPath)
-    .pipe(Effect.catchAll(() => Effect.succeed("")));
-  if (content === "") {
+    .pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+  if (content === null) {
+    return { ...fallback, unreadable: true };
+  }
+
+  if (content.trim() === "") {
     return fallback;
   }
 
@@ -105,13 +121,27 @@ export const readCliConfig = readCliConfigResult.pipe(Effect.map((result) => res
  *
  * Read-modify-write rather than a blind overwrite: the board is changing one
  * preference, not restating the whole file.
+ *
+ * Which is exactly why a file that could not be read stops it. The read falls
+ * back to the defaults, so writing it back would not be a merge — it would
+ * replace every setting the file had with a default, on a keystroke that meant
+ * to change one preference, moments after the launch told the reader their file
+ * was worth fixing. One preference is not worth the rest of them, so this does
+ * nothing and the file stays as it was, still fixable.
  */
 export const saveResumeAction = (action: ResumeAction): Promise<void> =>
   Effect.runPromise(
     Effect.gen(function* () {
-      const current = yield* readCliConfig;
+      const current = yield* readCliConfigResult;
 
-      yield* writeCliConfig({ ...current, browse: { ...current.browse, resumeAction: action } });
+      if (current.unreadable) {
+        return;
+      }
+
+      yield* writeCliConfig({
+        ...current.config,
+        browse: { ...current.config.browse, resumeAction: action },
+      });
     }).pipe(
       Effect.provide(CliConfigBaseDir.Live),
       Effect.provide(EnvService.Live),

--- a/src/cli/config/cliConfigStore.ts
+++ b/src/cli/config/cliConfigStore.ts
@@ -43,25 +43,45 @@ export const cliConfigExists = Effect.gen(function* () {
   return yield* fs.exists(configPath).pipe(Effect.catchAll(() => Effect.succeed(false)));
 });
 
+/** What a read found, for the one caller that has somebody to tell about it. */
+export type CliConfigResult = {
+  config: CliConfig;
+  /** Where the settings live, whether or not this read got anything from it. */
+  configPath: string;
+  /**
+   * Whether a file was there and could not be understood.
+   *
+   * A missing file is not unreadable — that is a first launch, and the defaults
+   * are the right answer rather than a thing worth mentioning.
+   */
+  unreadable: boolean;
+};
+
 /**
  * Reads stored settings, falling back to the defaults rather than failing.
  *
  * This runs before anything else on every launch, so a file somebody edited by
  * hand must cost them their preferences and nothing more.
+ *
+ * Nothing is printed from here. The file is opened two or three times on a
+ * single launch and each read would be entitled to complain about the same
+ * file, so the reporting belongs to the caller that has a reader in front of it
+ * — see `loadStoredOptions`.
  */
-export const readCliConfig = Effect.gen(function* () {
+export const readCliConfigResult = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
   const configPath = yield* getCliConfigPath;
+  const fallback: CliConfigResult = { config: defaultCliConfig, configPath, unreadable: false };
 
   if (!(yield* cliConfigExists)) {
-    return defaultCliConfig;
+    return fallback;
   }
 
   const content = yield* fs
     .readFileString(configPath)
     .pipe(Effect.catchAll(() => Effect.succeed("")));
   if (content === "") {
-    return defaultCliConfig;
+    return fallback;
   }
 
   const raw = yield* Effect.try({
@@ -71,12 +91,14 @@ export const readCliConfig = Effect.gen(function* () {
 
   const parsed = parseCliConfig(raw);
   if (parsed === null) {
-    yield* Effect.logWarning(`Ignoring unreadable Lantern settings at ${configPath}`);
-    return defaultCliConfig;
+    return { ...fallback, unreadable: true };
   }
 
-  return parsed;
+  return { config: parsed, configPath, unreadable: false };
 });
+
+/** The settings alone, for the callers that have nothing to say about them. */
+export const readCliConfig = readCliConfigResult.pipe(Effect.map((result) => result.config));
 
 /**
  * Remembers a new choice of what Enter does, leaving every other setting alone.

--- a/src/cli/config/describeUnreadableSettings.test.ts
+++ b/src/cli/config/describeUnreadableSettings.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { describeUnreadableSettings } from "./describeUnreadableSettings.ts";
+
+describe("describeUnreadableSettings", () => {
+  it("names the file, so the reader knows which one to open", () => {
+    const message = describeUnreadableSettings("/root/.lantern/config.json");
+
+    expect(message).toContain("/root/.lantern/config.json");
+  });
+
+  /** Nothing stopped; the reader needs to know their settings were dropped. */
+  it("says what happened instead of stopping", () => {
+    const message = describeUnreadableSettings("/root/.lantern/config.json");
+
+    expect(message).toContain("defaults");
+  });
+
+  it("says how to get back to a working file", () => {
+    const message = describeUnreadableSettings("/root/.lantern/config.json");
+
+    expect(message).toContain("delete");
+  });
+
+  /** The raw log frame this replaced read as a crash. This is not one. */
+  it("reads as a notice rather than a failure", () => {
+    const message = describeUnreadableSettings("/root/.lantern/config.json").toLowerCase();
+
+    expect(message).not.toContain("error");
+    expect(message).not.toContain("warn");
+    expect(message).not.toContain("fiber");
+  });
+});

--- a/src/cli/config/describeUnreadableSettings.test.ts
+++ b/src/cli/config/describeUnreadableSettings.test.ts
@@ -18,7 +18,18 @@ describe("describeUnreadableSettings", () => {
   it("says how to get back to a working file", () => {
     const message = describeUnreadableSettings("/root/.lantern/config.json");
 
-    expect(message).toContain("delete");
+    expect(message).toContain("Deleting it");
+  });
+
+  /**
+   * Both ways in reach this message, and naming only one would send half the
+   * readers looking in the wrong place.
+   */
+  it("does not blame the JSON, which is only one of the two ways here", () => {
+    const message = describeUnreadableSettings("/root/.lantern/config.json");
+
+    expect(message).toContain("not allowed to");
+    expect(message).not.toMatch(/^Fix the JSON/mu);
   });
 
   /** The raw log frame this replaced read as a crash. This is not one. */

--- a/src/cli/config/describeUnreadableSettings.ts
+++ b/src/cli/config/describeUnreadableSettings.ts
@@ -1,0 +1,19 @@
+/**
+ * What to print when the settings file cannot be understood.
+ *
+ * Losing a settings file costs a port and a directory, not a launch — so this
+ * says what was dropped and carries on, rather than reading like the stop it is
+ * not. The path is spelled out because the file is somewhere nobody browses to
+ * by accident, and both ways out are given: the file is usually one hand-edited
+ * comma away from working, but deleting it is the answer for anybody who no
+ * longer remembers what was in it.
+ */
+export const describeUnreadableSettings = (configPath: string): string =>
+  [
+    `Your Lantern settings could not be read, so this run uses the defaults.`,
+    "",
+    `  ${configPath}`,
+    "",
+    "Fix the JSON in that file to get your settings back, or delete it to start",
+    "over from the defaults.",
+  ].join("\n");

--- a/src/cli/config/describeUnreadableSettings.ts
+++ b/src/cli/config/describeUnreadableSettings.ts
@@ -1,12 +1,16 @@
 /**
- * What to print when the settings file cannot be understood.
+ * What to print when the settings file is there but gave nothing up.
  *
  * Losing a settings file costs a port and a directory, not a launch — so this
  * says what was dropped and carries on, rather than reading like the stop it is
  * not. The path is spelled out because the file is somewhere nobody browses to
- * by accident, and both ways out are given: the file is usually one hand-edited
- * comma away from working, but deleting it is the answer for anybody who no
- * longer remembers what was in it.
+ * by accident.
+ *
+ * It stops short of naming the fault. The two ways to reach this are a file
+ * that will not parse and a file that will not open, and the advice for one is
+ * wrong for the other — telling somebody whose file is owned by root to check
+ * their commas would send them looking in the wrong place. "Open it and see" is
+ * true of both, and the file itself will make which one obvious.
  */
 export const describeUnreadableSettings = (configPath: string): string =>
   [
@@ -14,6 +18,6 @@ export const describeUnreadableSettings = (configPath: string): string =>
     "",
     `  ${configPath}`,
     "",
-    "Fix the JSON in that file to get your settings back, or delete it to start",
-    "over from the defaults.",
+    "Open that file to see why — bad JSON and a file Lantern is not allowed to",
+    "read both land here. Deleting it starts again from the defaults.",
   ].join("\n");

--- a/src/cli/config/loadStoredOptions.ts
+++ b/src/cli/config/loadStoredOptions.ts
@@ -1,8 +1,11 @@
 import { NodeContext } from "@effect/platform-node";
 import { Effect } from "effect";
 import { EnvService } from "../../server/core/platform/services/EnvService.ts";
+import { serverLoggerLayer } from "../../server/logging.ts";
+import { noticeOnce } from "../notice.ts";
 import type { CliConfig } from "./cliConfig.ts";
-import { CliConfigBaseDir, readCliConfig } from "./cliConfigStore.ts";
+import { CliConfigBaseDir, readCliConfigResult } from "./cliConfigStore.ts";
+import { describeUnreadableSettings } from "./describeUnreadableSettings.ts";
 
 /**
  * Reads `~/.lantern/config.json` on its own, before any of Lantern's layers
@@ -11,12 +14,29 @@ import { CliConfigBaseDir, readCliConfig } from "./cliConfigStore.ts";
  * The settings decide the port the server binds and the directory the cache
  * lives in, both of which are needed to build those layers — so this one read
  * has to stand outside them.
+ *
+ * It is also where a file that could not be read is mentioned, because this is
+ * the read whose answer is actually used. Said through `noticeOnce`, so the
+ * launches that load settings more than once still only say it the once.
+ *
+ * The logger is provided even though nothing here logs on purpose: without it
+ * anything that did would land as Effect's raw `timestamp=… level=… fiber=…`
+ * frame, which is not a thing to show somebody who typed one word.
  */
 export const loadStoredOptions = (): Promise<CliConfig> =>
   Effect.runPromise(
-    readCliConfig.pipe(
+    Effect.gen(function* () {
+      const result = yield* readCliConfigResult;
+
+      if (result.unreadable) {
+        yield* Effect.sync(() => noticeOnce(describeUnreadableSettings(result.configPath)));
+      }
+
+      return result.config;
+    }).pipe(
       Effect.provide(CliConfigBaseDir.Live),
       Effect.provide(EnvService.Live),
       Effect.provide(NodeContext.layer),
+      Effect.provide(serverLoggerLayer),
     ),
   );

--- a/src/cli/config/loadStoredOptions.ts
+++ b/src/cli/config/loadStoredOptions.ts
@@ -17,11 +17,14 @@ import { describeUnreadableSettings } from "./describeUnreadableSettings.ts";
  *
  * It is also where a file that could not be read is mentioned, because this is
  * the read whose answer is actually used. Said through `noticeOnce`, so the
- * launches that load settings more than once still only say it the once.
+ * launches that load settings more than once — the wizard reads them, and a
+ * wizard somebody backed out of is followed by another read — still only say it
+ * the once.
  *
- * The logger is provided even though nothing here logs on purpose: without it
- * anything that did would land as Effect's raw `timestamp=… level=… fiber=…`
- * frame, which is not a thing to show somebody who typed one word.
+ * The logger is provided as a net, not because anything below logs today.
+ * Nothing this far up the launch has the server's layers yet, so anything that
+ * did log would land as Effect's raw `timestamp=… level=… fiber=…` frame, which
+ * is not a thing to show somebody who typed one word.
  */
 export const loadStoredOptions = (): Promise<CliConfig> =>
   Effect.runPromise(

--- a/src/cli/firstRunWizard.ts
+++ b/src/cli/firstRunWizard.ts
@@ -1,17 +1,22 @@
 import { NodeContext } from "@effect/platform-node";
 import { Effect } from "effect";
 import { EnvService } from "../server/core/platform/services/EnvService.ts";
+import { serverLoggerLayer } from "../server/logging.ts";
 import type { CliConfig } from "./config/cliConfig.ts";
 import { CliConfigBaseDir, cliConfigExists } from "./config/cliConfigStore.ts";
 import { loadStoredOptions } from "./config/loadStoredOptions.ts";
 import { shouldRunWizard } from "./firstRun.ts";
 
+// The logger is provided here as it is everywhere else that runs before the
+// server's layers exist: anything that logs from one of these standalone reads
+// would otherwise print Effect's raw `timestamp=… level=… fiber=…` frame.
 const configExists = (): Promise<boolean> =>
   Effect.runPromise(
     cliConfigExists.pipe(
       Effect.provide(CliConfigBaseDir.Live),
       Effect.provide(EnvService.Live),
       Effect.provide(NodeContext.layer),
+      Effect.provide(serverLoggerLayer),
     ),
   );
 

--- a/src/cli/notice.test.ts
+++ b/src/cli/notice.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { makeNoticeOnce } from "./notice.ts";
+
+describe("makeNoticeOnce", () => {
+  it("writes the message, with the newline the caller did not have to add", () => {
+    const written: string[] = [];
+    const notice = makeNoticeOnce((line) => written.push(line));
+
+    notice("Settings could not be read.");
+
+    expect(written).toEqual(["Settings could not be read.\n"]);
+  });
+
+  /** The settings file is read two or three times on a single launch. */
+  it("says the same message once, however many times it is asked", () => {
+    const written: string[] = [];
+    const notice = makeNoticeOnce((line) => written.push(line));
+
+    notice("Settings could not be read.");
+    notice("Settings could not be read.");
+    notice("Settings could not be read.");
+
+    expect(written).toHaveLength(1);
+  });
+
+  it("still says a different message", () => {
+    const written: string[] = [];
+    const notice = makeNoticeOnce((line) => written.push(line));
+
+    notice("first");
+    notice("second");
+
+    expect(written).toEqual(["first\n", "second\n"]);
+  });
+
+  /** Two files unreadable is two problems, and the path is what tells them apart. */
+  it("treats messages naming different paths as different messages", () => {
+    const written: string[] = [];
+    const notice = makeNoticeOnce((line) => written.push(line));
+
+    notice("Could not read /a/config.json");
+    notice("Could not read /b/config.json");
+
+    expect(written).toHaveLength(2);
+  });
+
+  it("keeps its own record, so one instance cannot silence another", () => {
+    const first: string[] = [];
+    const second: string[] = [];
+    const noticeFirst = makeNoticeOnce((line) => first.push(line));
+    const noticeSecond = makeNoticeOnce((line) => second.push(line));
+
+    noticeFirst("same");
+    noticeSecond("same");
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+  });
+});

--- a/src/cli/notice.test.ts
+++ b/src/cli/notice.test.ts
@@ -11,7 +11,7 @@ describe("makeNoticeOnce", () => {
     expect(written).toEqual(["Settings could not be read.\n"]);
   });
 
-  /** The settings file is read two or three times on a single launch. */
+  /** A launch that offers the wizard and is refused loads settings twice. */
   it("says the same message once, however many times it is asked", () => {
     const written: string[] = [];
     const notice = makeNoticeOnce((line) => written.push(line));

--- a/src/cli/notice.ts
+++ b/src/cli/notice.ts
@@ -1,11 +1,17 @@
 /**
  * Says something to the reader once, however many times it comes up.
  *
- * The settings file is opened two or three times on a single launch — the
- * update notice reads it, the wizard asks whether it exists, the options are
- * loaded from it — and each read is entitled to complain about a file it could
- * not parse. One launch is one problem, so the first complaint is the one that
- * gets printed and the rest are dropped.
+ * Settings are loaded more than once on some launches — the wizard reads them,
+ * and a wizard somebody backed out of is followed by another read — and each of
+ * those reads finds the same broken file and has the same thing to say about
+ * it. One launch is one problem, so the first telling is the one that gets
+ * printed and the rest are dropped.
+ *
+ * Deduplicated on the finished message, which carries the path, so two
+ * different files are still two different notices. That does mean two genuinely
+ * separate problems that happen to read identically would collapse into one —
+ * fine while every caller says something naming what it is about, and the
+ * reason this is not the right tool for anything that legitimately repeats.
  *
  * The writer is a parameter so the remembering can be tested without a process
  * to write to; `noticeOnce` below is the one that talks to a terminal.

--- a/src/cli/notice.ts
+++ b/src/cli/notice.ts
@@ -1,0 +1,35 @@
+/**
+ * Says something to the reader once, however many times it comes up.
+ *
+ * The settings file is opened two or three times on a single launch — the
+ * update notice reads it, the wizard asks whether it exists, the options are
+ * loaded from it — and each read is entitled to complain about a file it could
+ * not parse. One launch is one problem, so the first complaint is the one that
+ * gets printed and the rest are dropped.
+ *
+ * The writer is a parameter so the remembering can be tested without a process
+ * to write to; `noticeOnce` below is the one that talks to a terminal.
+ */
+export const makeNoticeOnce = (write: (line: string) => void) => {
+  const said = new Set<string>();
+
+  return (message: string): void => {
+    if (said.has(message)) {
+      return;
+    }
+
+    said.add(message);
+    write(`${message}\n`);
+  };
+};
+
+/**
+ * The process-wide notice writer.
+ *
+ * stderr, like every other thing Lantern says on the way up: `lantern | tee` is
+ * still somebody at a terminal, and a redirected stdout is not a reason to keep
+ * a lost preference quiet.
+ */
+export const noticeOnce = makeNoticeOnce((line) => {
+  process.stderr.write(line);
+});

--- a/src/cli/serverPlan.test.ts
+++ b/src/cli/serverPlan.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { describeAlreadyServing, describePortOccupied, resolveServerPlan } from "./serverPlan.ts";
+
+describe("resolveServerPlan", () => {
+  it("starts the server when nothing holds the port", () => {
+    expect(resolveServerPlan({ mode: "both", presence: "free" })).toBe("start");
+    expect(resolveServerPlan({ mode: "server", presence: "free" })).toBe("start");
+  });
+
+  /** The whole point: a second terminal gets a board, not a crash. */
+  it("attaches to a Lantern that is already serving", () => {
+    expect(resolveServerPlan({ mode: "both", presence: "lantern" })).toBe("attach");
+  });
+
+  /**
+   * `--server-only` asked for a server and there is nowhere to put one. There
+   * is no board to fall back to, so this has to be said rather than worked
+   * around.
+   */
+  it("has nothing to offer --server-only when a Lantern already serves", () => {
+    expect(resolveServerPlan({ mode: "server", presence: "lantern" })).toBe("blocked");
+  });
+
+  /** Not a Lantern, so there is no running web UI to attach to. */
+  it("stops when something else holds the port, whichever was asked for", () => {
+    expect(resolveServerPlan({ mode: "both", presence: "occupied" })).toBe("blocked");
+    expect(resolveServerPlan({ mode: "server", presence: "occupied" })).toBe("blocked");
+  });
+});
+
+describe("describeAlreadyServing", () => {
+  it("says where the running web UI is", () => {
+    const message = describeAlreadyServing("http://127.0.0.1:3000", "lantern");
+
+    expect(message).toContain("http://127.0.0.1:3000");
+  });
+
+  it("offers both ways on: another port, or the board", () => {
+    const message = describeAlreadyServing("http://127.0.0.1:3000", "lantern");
+
+    expect(message).toContain("lantern --port");
+    expect(message).toContain("lantern --cli-only");
+  });
+
+  it("uses the name the program was invoked under", () => {
+    expect(describeAlreadyServing("http://127.0.0.1:3000", "lantern-viewer")).toContain(
+      "lantern-viewer --cli-only",
+    );
+  });
+
+  /** Nothing broke; the thing that was wanted is already there. */
+  it("does not read as a crash", () => {
+    const message = describeAlreadyServing("http://127.0.0.1:3000", "lantern").toLowerCase();
+
+    expect(message).not.toContain("eaddrinuse");
+    expect(message).not.toContain("error");
+  });
+});
+
+describe("describePortOccupied", () => {
+  it("names the address that is taken", () => {
+    const message = describePortOccupied("127.0.0.1", 3000, "lantern");
+
+    expect(message).toContain("127.0.0.1:3000");
+  });
+
+  /** The reader has to be told this is somebody else's, not another Lantern. */
+  it("says it is not a Lantern on the other end", () => {
+    expect(describePortOccupied("127.0.0.1", 3000, "lantern")).toContain("Lantern");
+  });
+
+  it("offers both ways on: another port, or the board", () => {
+    const message = describePortOccupied("127.0.0.1", 3000, "lantern");
+
+    expect(message).toContain("lantern --port");
+    expect(message).toContain("lantern --cli-only");
+  });
+
+  it("does not spell the failure the way the operating system did", () => {
+    expect(describePortOccupied("127.0.0.1", 3000, "lantern").toLowerCase()).not.toContain(
+      "eaddrinuse",
+    );
+  });
+});

--- a/src/cli/serverPlan.test.ts
+++ b/src/cli/serverPlan.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { describeAlreadyServing, describePortOccupied, resolveServerPlan } from "./serverPlan.ts";
+import {
+  describeAlreadyServing,
+  describePortOccupied,
+  describePortTaken,
+  resolveServerPlan,
+} from "./serverPlan.ts";
 
 describe("resolveServerPlan", () => {
   it("starts the server when nothing holds the port", () => {
@@ -30,27 +35,48 @@ describe("resolveServerPlan", () => {
 
 describe("describeAlreadyServing", () => {
   it("says where the running web UI is", () => {
-    const message = describeAlreadyServing("http://127.0.0.1:3000", "lantern");
+    expect(describeAlreadyServing("127.0.0.1", 3000, "lantern")).toContain("http://127.0.0.1:3000");
+  });
+
+  /** The address has to be one a browser can open, not the bind address. */
+  it("turns a wildcard bind into an address that can be opened", () => {
+    const message = describeAlreadyServing("0.0.0.0", 3000, "lantern");
 
     expect(message).toContain("http://127.0.0.1:3000");
+    expect(message).not.toContain("0.0.0.0");
   });
 
   it("offers both ways on: another port, or the board", () => {
-    const message = describeAlreadyServing("http://127.0.0.1:3000", "lantern");
+    const message = describeAlreadyServing("127.0.0.1", 3000, "lantern");
 
-    expect(message).toContain("lantern --port");
+    expect(message).toContain("lantern --port 3001");
     expect(message).toContain("lantern --cli-only");
   });
 
+  /** Retrying the port that just turned you away is not advice. */
+  it("suggests a port other than the one that was taken", () => {
+    const message = describeAlreadyServing("127.0.0.1", 3001, "lantern");
+
+    expect(message).toContain("lantern --port 3002");
+  });
+
   it("uses the name the program was invoked under", () => {
-    expect(describeAlreadyServing("http://127.0.0.1:3000", "lantern-viewer")).toContain(
+    expect(describeAlreadyServing("127.0.0.1", 3000, "lantern-viewer")).toContain(
       "lantern-viewer --cli-only",
     );
   });
 
+  /**
+   * The promise this message makes. Without it the reader has no reason to
+   * believe the Lantern in the other terminal survived their mistake.
+   */
+  it("says the running one was left alone", () => {
+    expect(describeAlreadyServing("127.0.0.1", 3000, "lantern")).toContain("has not been touched");
+  });
+
   /** Nothing broke; the thing that was wanted is already there. */
   it("does not read as a crash", () => {
-    const message = describeAlreadyServing("http://127.0.0.1:3000", "lantern").toLowerCase();
+    const message = describeAlreadyServing("127.0.0.1", 3000, "lantern").toLowerCase();
 
     expect(message).not.toContain("eaddrinuse");
     expect(message).not.toContain("error");
@@ -59,25 +85,62 @@ describe("describeAlreadyServing", () => {
 
 describe("describePortOccupied", () => {
   it("names the address that is taken", () => {
-    const message = describePortOccupied("127.0.0.1", 3000, "lantern");
-
-    expect(message).toContain("127.0.0.1:3000");
+    expect(describePortOccupied("127.0.0.1", 3000, "lantern")).toContain("127.0.0.1:3000");
   });
 
-  /** The reader has to be told this is somebody else's, not another Lantern. */
-  it("says it is not a Lantern on the other end", () => {
-    expect(describePortOccupied("127.0.0.1", 3000, "lantern")).toContain("Lantern");
+  /**
+   * Asserted against the other two messages rather than for a word they share:
+   * printing "already serving" at somebody whose port is held by a database is
+   * the mistake worth catching, and every looser assertion passes for it.
+   */
+  it("says it is somebody else on the port, not a Lantern", () => {
+    const message = describePortOccupied("127.0.0.1", 3000, "lantern");
+
+    expect(message).toContain("is not Lantern");
+    expect(message).not.toContain("already serving");
+    expect(message).not.toContain("cannot say");
   });
 
   it("offers both ways on: another port, or the board", () => {
     const message = describePortOccupied("127.0.0.1", 3000, "lantern");
 
-    expect(message).toContain("lantern --port");
+    expect(message).toContain("lantern --port 3001");
     expect(message).toContain("lantern --cli-only");
   });
 
   it("does not spell the failure the way the operating system did", () => {
     expect(describePortOccupied("127.0.0.1", 3000, "lantern").toLowerCase()).not.toContain(
+      "eaddrinuse",
+    );
+  });
+});
+
+describe("describePortTaken", () => {
+  it("names the address that could not be bound", () => {
+    expect(describePortTaken("127.0.0.1", 3000, "lantern")).toContain("127.0.0.1:3000");
+  });
+
+  /**
+   * The reason this message exists. The bind proves the port is held; nothing
+   * proved what holds it, so neither of the other two messages may be printed.
+   */
+  it("claims nothing about what is on the port", () => {
+    const message = describePortTaken("127.0.0.1", 3000, "lantern");
+
+    expect(message).toContain("cannot say");
+    expect(message).not.toContain("is not Lantern");
+    expect(message).not.toContain("already serving");
+  });
+
+  it("offers both ways on: another port, or the board", () => {
+    const message = describePortTaken("127.0.0.1", 3000, "lantern");
+
+    expect(message).toContain("lantern --port 3001");
+    expect(message).toContain("lantern --cli-only");
+  });
+
+  it("does not spell the failure the way the operating system did", () => {
+    expect(describePortTaken("127.0.0.1", 3000, "lantern").toLowerCase()).not.toContain(
       "eaddrinuse",
     );
   });

--- a/src/cli/serverPlan.ts
+++ b/src/cli/serverPlan.ts
@@ -1,0 +1,83 @@
+import type { ServerPresence } from "./serverPresence.ts";
+
+/**
+ * What this launch does about the web server.
+ *
+ * - `start` — bind the port, as every launch used to.
+ * - `attach` — a Lantern is already serving; open the board against it and
+ *   leave the server that is up alone.
+ * - `blocked` — the port cannot be had and there is nothing sensible to do
+ *   instead.
+ */
+export type ServerPlan = "start" | "attach" | "blocked";
+
+export type ServerPlanInput = {
+  /** Only the two modes that want a server ever get this far. */
+  mode: "both" | "server";
+  presence: ServerPresence;
+};
+
+/**
+ * Decides whether this launch starts a web server, joins one, or stops.
+ *
+ * One web server at a time is the rule, and the second `lantern` in a second
+ * terminal is the case it exists for: the board reads the cache directly rather
+ * than over HTTP, so it needs no server of its own and there is nothing to be
+ * gained from starting one. `--server-only` is the mode with no board to fall
+ * back to, which is why the same "already serving" answer stops it instead.
+ */
+export const resolveServerPlan = ({ mode, presence }: ServerPlanInput): ServerPlan => {
+  if (presence === "free") {
+    return "start";
+  }
+
+  if (presence === "lantern" && mode === "both") {
+    return "attach";
+  }
+
+  return "blocked";
+};
+
+/** The two ways on, printed together because either may be the one wanted. */
+const waysOn = (programName: string): readonly string[] => {
+  const routes: readonly (readonly [string, string])[] = [
+    [`${programName} --port 3001`, "to run a second web UI of your own"],
+    [`${programName} --cli-only`, "to browse here, without a web UI"],
+  ];
+  const column = Math.max(...routes.map(([command]) => command.length));
+
+  return routes.map(([command, what]) => `  ${command.padEnd(column)}   ${what}`);
+};
+
+/**
+ * What `--server-only` is told when a Lantern already holds the port.
+ *
+ * The running one is left alone and its address is printed, because "already
+ * serving" is nine times out of ten good news badly timed — the web UI that was
+ * wanted is up, in another terminal, and the reader only needs to be pointed at
+ * it.
+ */
+export const describeAlreadyServing = (url: string, programName: string): string =>
+  [
+    `Lantern is already serving the web UI at ${url}.`,
+    "",
+    ...waysOn(programName),
+    "",
+    "The one already running has not been touched.",
+  ].join("\n");
+
+/**
+ * What to print when the port is held by something that is not Lantern.
+ *
+ * Named as somebody else's rather than as a failure of Lantern's, because that
+ * is what it is, and because the reader is the only one who can say whether the
+ * answer is to move Lantern or to stop whatever is there.
+ */
+export const describePortOccupied = (hostname: string, port: number, programName: string): string =>
+  [
+    `Something that is not Lantern is already listening on ${hostname}:${port}.`,
+    "",
+    ...waysOn(programName),
+    "",
+    `Set "port" in your Lantern settings to make a different choice stick.`,
+  ].join("\n");

--- a/src/cli/serverPlan.ts
+++ b/src/cli/serverPlan.ts
@@ -1,4 +1,5 @@
-import type { ServerPresence } from "./serverPresence.ts";
+import type { RunMode } from "./runMode.ts";
+import { type ServerPresence, serverUrl } from "./serverPresence.ts";
 
 /**
  * What this launch does about the web server.
@@ -11,10 +12,20 @@ import type { ServerPresence } from "./serverPresence.ts";
  */
 export type ServerPlan = "start" | "attach" | "blocked";
 
+/**
+ * The run modes that want a web server.
+ *
+ * `Extract` rather than a hand-written pair, so this names members of `RunMode`
+ * and a rename over there breaks here. Deliberately not `Exclude`, which would
+ * silently widen to admit any mode added later — the whole point is that a new
+ * mode has to come and say what it wants from a server.
+ */
+export type ServerRunMode = Extract<RunMode, "both" | "server">;
+
 export type ServerPlanInput = {
-  /** Only the two modes that want a server ever get this far. */
-  mode: "both" | "server";
-  presence: ServerPresence;
+  /** Only the modes that want a server ever get this far. */
+  readonly mode: ServerRunMode;
+  readonly presence: ServerPresence;
 };
 
 /**
@@ -38,10 +49,15 @@ export const resolveServerPlan = ({ mode, presence }: ServerPlanInput): ServerPl
   return "blocked";
 };
 
-/** The two ways on, printed together because either may be the one wanted. */
-const waysOn = (programName: string): readonly string[] => {
+/**
+ * The two ways on, printed together because either may be the one wanted.
+ *
+ * The port offered is the one next to the port that failed, rather than a fixed
+ * 3001, so the advice is never to retry the port that just turned them away.
+ */
+const waysOn = (programName: string, port: number): readonly string[] => {
   const routes: readonly (readonly [string, string])[] = [
-    [`${programName} --port 3001`, "to run a second web UI of your own"],
+    [`${programName} --port ${port + 1}`, "to run a second web UI of your own"],
     [`${programName} --cli-only`, "to browse here, without a web UI"],
   ];
   const column = Math.max(...routes.map(([command]) => command.length));
@@ -50,18 +66,24 @@ const waysOn = (programName: string): readonly string[] => {
 };
 
 /**
- * What `--server-only` is told when a Lantern already holds the port.
+ * What a launch is told when a Lantern already holds the port and this one
+ * cannot use it — `--server-only`, which has no board to fall back to, or a
+ * bare `lantern` that lost the port between the check and the bind.
  *
  * The running one is left alone and its address is printed, because "already
  * serving" is nine times out of ten good news badly timed — the web UI that was
  * wanted is up, in another terminal, and the reader only needs to be pointed at
  * it.
  */
-export const describeAlreadyServing = (url: string, programName: string): string =>
+export const describeAlreadyServing = (
+  hostname: string,
+  port: number,
+  programName: string,
+): string =>
   [
-    `Lantern is already serving the web UI at ${url}.`,
+    `Lantern is already serving the web UI at ${serverUrl(hostname, port)}.`,
     "",
-    ...waysOn(programName),
+    ...waysOn(programName, port),
     "",
     "The one already running has not been touched.",
   ].join("\n");
@@ -77,7 +99,27 @@ export const describePortOccupied = (hostname: string, port: number, programName
   [
     `Something that is not Lantern is already listening on ${hostname}:${port}.`,
     "",
-    ...waysOn(programName),
+    ...waysOn(programName, port),
     "",
     `Set "port" in your Lantern settings to make a different choice stick.`,
+  ].join("\n");
+
+/**
+ * What to print when the port is taken but nothing on it would say by what.
+ *
+ * The bind is what proves the port is held; the check before it only ever
+ * proves what answered. When the two disagree — a process that accepts
+ * connections and never replies, a Lantern too busy to answer inside the
+ * check's budget — the honest thing is to say the port is taken and stop, not
+ * to guess at the tenant. Naming the wrong one sends the reader to fix a
+ * machine that has nothing wrong with it.
+ */
+export const describePortTaken = (hostname: string, port: number, programName: string): string =>
+  [
+    `Lantern could not bind ${hostname}:${port}, because something else is holding it.`,
+    "",
+    ...waysOn(programName, port),
+    "",
+    "Whatever is on that port did not answer, so Lantern cannot say whether it",
+    "is another Lantern or something unrelated.",
   ].join("\n");

--- a/src/cli/serverPresence.test.ts
+++ b/src/cli/serverPresence.test.ts
@@ -1,0 +1,143 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { probeHostname, probeServerPresence, probeUrl, readsAsLantern } from "./serverPresence.ts";
+
+describe("probeHostname", () => {
+  /** You cannot open a connection to a wildcard; loopback is where it answers. */
+  it("asks loopback about a server bound to every IPv4 address", () => {
+    expect(probeHostname("0.0.0.0")).toBe("127.0.0.1");
+  });
+
+  it("asks IPv6 loopback about a server bound to every address", () => {
+    expect(probeHostname("::")).toBe("::1");
+  });
+
+  it("asks loopback when no bind address was resolved at all", () => {
+    expect(probeHostname("")).toBe("127.0.0.1");
+  });
+
+  it("asks a real bind address about itself", () => {
+    expect(probeHostname("127.0.0.1")).toBe("127.0.0.1");
+    expect(probeHostname("192.168.1.10")).toBe("192.168.1.10");
+    expect(probeHostname("lantern.local")).toBe("lantern.local");
+  });
+});
+
+describe("probeUrl", () => {
+  it("builds the address of the one route that answers without a password", () => {
+    expect(probeUrl("127.0.0.1", 3000)).toBe("http://127.0.0.1:3000/api/version");
+  });
+
+  /** Without the brackets this is a host called `::1` on port `3000`. */
+  it("brackets an IPv6 address", () => {
+    expect(probeUrl("::1", 3000)).toBe("http://[::1]:3000/api/version");
+  });
+
+  it("leaves an already bracketed address alone", () => {
+    expect(probeUrl("[::1]", 3000)).toBe("http://[::1]:3000/api/version");
+  });
+
+  it("does not bracket a hostname", () => {
+    expect(probeUrl("lantern.local", 8080)).toBe("http://lantern.local:8080/api/version");
+  });
+});
+
+describe("readsAsLantern", () => {
+  it("recognises the version Lantern answers with", () => {
+    expect(readsAsLantern({ version: "0.6.0" })).toBe(true);
+  });
+
+  it("does not take somebody else's JSON for a Lantern", () => {
+    expect(readsAsLantern({ status: "ok" })).toBe(false);
+    expect(readsAsLantern({ version: 6 })).toBe(false);
+    expect(readsAsLantern(null)).toBe(false);
+    expect(readsAsLantern("0.6.0")).toBe(false);
+  });
+});
+
+/**
+ * Every stand-in stays up for the whole file, and they all come down together
+ * at the end. Closing one between probes drops a connection the client is still
+ * holding, which costs the next request — an artefact of asking four questions
+ * in one process, and not something a launch ever does.
+ */
+describe("probeServerPresence", () => {
+  const servers: Server[] = [];
+
+  const listen = (handler: Parameters<typeof createServer>[1]): Promise<number> =>
+    new Promise((resolve) => {
+      const created = createServer(handler);
+      servers.push(created);
+      created.listen(0, "127.0.0.1", () => {
+        const info = created.address();
+        resolve(typeof info === "object" && info !== null ? info.port : 0);
+      });
+    });
+
+  const close = (server: Server): Promise<void> =>
+    new Promise((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+
+  let lanternPort = 0;
+  let strangerPort = 0;
+  let refusingPort = 0;
+
+  beforeAll(async () => {
+    lanternPort = await listen((request, response) => {
+      if (request.url === "/api/version") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ version: "0.6.0" }));
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+
+    strangerPort = await listen((_request, response) => {
+      response.writeHead(200, { "content-type": "text/html" });
+      response.end("<h1>Directory listing</h1>");
+    });
+
+    refusingPort = await listen((_request, response) => {
+      response.writeHead(404);
+      response.end();
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all(servers.map((server) => close(server)));
+    servers.length = 0;
+  });
+
+  it("finds a Lantern behind the port it answers on", async () => {
+    expect(await probeServerPresence("127.0.0.1", lanternPort)).toBe("lantern");
+  });
+
+  /** Something is there, but it is not going to serve the web UI. */
+  it("calls a port held by something else occupied", async () => {
+    expect(await probeServerPresence("127.0.0.1", strangerPort)).toBe("occupied");
+  });
+
+  it("calls a server that refuses the route occupied rather than free", async () => {
+    expect(await probeServerPresence("127.0.0.1", refusingPort)).toBe("occupied");
+  });
+
+  /**
+   * The port has to come back free for the common case — one Lantern, nothing
+   * else — or every launch would refuse to start a server.
+   */
+  it("calls a port nothing answers on free", async () => {
+    const port = await listen((_request, response) => {
+      response.end();
+    });
+    const spare = servers.pop();
+    if (spare !== undefined) {
+      await close(spare);
+    }
+
+    expect(await probeServerPresence("127.0.0.1", port)).toBe("free");
+  });
+});

--- a/src/cli/serverPresence.test.ts
+++ b/src/cli/serverPresence.test.ts
@@ -1,6 +1,12 @@
 import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { probeHostname, probeServerPresence, probeUrl, readsAsLantern } from "./serverPresence.ts";
+import {
+  probeHostname,
+  probeServerPresence,
+  probeUrl,
+  readsAsLantern,
+  serverUrl,
+} from "./serverPresence.ts";
 
 describe("probeHostname", () => {
   /** You cannot open a connection to a wildcard; loopback is where it answers. */
@@ -21,24 +27,49 @@ describe("probeHostname", () => {
     expect(probeHostname("192.168.1.10")).toBe("192.168.1.10");
     expect(probeHostname("lantern.local")).toBe("lantern.local");
   });
+
+  /** `serverUrl` and `probeUrl` apply it to addresses it has already answered. */
+  it("leaves its own answers alone", () => {
+    expect(probeHostname(probeHostname("0.0.0.0"))).toBe("127.0.0.1");
+    expect(probeHostname(probeHostname("::"))).toBe("::1");
+  });
 });
 
-describe("probeUrl", () => {
-  it("builds the address of the one route that answers without a password", () => {
-    expect(probeUrl("127.0.0.1", 3000)).toBe("http://127.0.0.1:3000/api/version");
+describe("serverUrl", () => {
+  it("builds an address a browser can open", () => {
+    expect(serverUrl("127.0.0.1", 3000)).toBe("http://127.0.0.1:3000");
   });
 
   /** Without the brackets this is a host called `::1` on port `3000`. */
   it("brackets an IPv6 address", () => {
-    expect(probeUrl("::1", 3000)).toBe("http://[::1]:3000/api/version");
-  });
-
-  it("leaves an already bracketed address alone", () => {
-    expect(probeUrl("[::1]", 3000)).toBe("http://[::1]:3000/api/version");
+    expect(serverUrl("::1", 3000)).toBe("http://[::1]:3000");
   });
 
   it("does not bracket a hostname", () => {
-    expect(probeUrl("lantern.local", 8080)).toBe("http://lantern.local:8080/api/version");
+    expect(serverUrl("lantern.local", 8080)).toBe("http://lantern.local:8080");
+  });
+
+  /**
+   * The conversion the callers used to have to remember. Printing
+   * `http://0.0.0.0:3000` at somebody is printing an address they cannot open.
+   */
+  it("turns a wildcard bind into an address that can be opened", () => {
+    expect(serverUrl("0.0.0.0", 3000)).toBe("http://127.0.0.1:3000");
+    expect(serverUrl("::", 3000)).toBe("http://[::1]:3000");
+  });
+});
+
+describe("probeUrl", () => {
+  it("asks the one route that answers without a password", () => {
+    expect(probeUrl("127.0.0.1", 3000)).toBe("http://127.0.0.1:3000/api/version");
+  });
+
+  it("brackets an IPv6 address", () => {
+    expect(probeUrl("::1", 3000)).toBe("http://[::1]:3000/api/version");
+  });
+
+  it("asks loopback about a wildcard bind", () => {
+    expect(probeUrl("0.0.0.0", 3000)).toBe("http://127.0.0.1:3000/api/version");
   });
 });
 
@@ -53,13 +84,32 @@ describe("readsAsLantern", () => {
     expect(readsAsLantern(null)).toBe(false);
     expect(readsAsLantern("0.6.0")).toBe(false);
   });
+
+  /**
+   * The known limit, pinned deliberately rather than left to be discovered:
+   * `/api/version` serves a bare version string, so anything else serving one
+   * at the same path passes. Recognising an older Lantern matters more than
+   * turning this case away — see the note on the function.
+   */
+  it("cannot tell another tool's version route apart, and says so here", () => {
+    expect(readsAsLantern({ version: "1.2.3", name: "something-else" })).toBe(true);
+  });
 });
 
 /**
- * Every stand-in stays up for the whole file, and they all come down together
- * at the end. Closing one between probes drops a connection the client is still
- * holding, which costs the next request — an artefact of asking four questions
- * in one process, and not something a launch ever does.
+ * Every stand-in server is listening before the first probe runs.
+ *
+ * Not tidiness — a constraint of the machine. Some loopback stacks will only
+ * carry a connection to a listener that existed before the process made its
+ * first outbound request; a server opened afterwards is refused, and the refusal
+ * is identical whether the request goes out over node:http or over undici. So a
+ * probe of a server started mid-file measures the loopback stack rather than
+ * this module. A launch never has that shape: the Lantern it asks about is in
+ * another process and was listening long before.
+ *
+ * The one thing worth pinning from that shape — asking twice in a single
+ * process, which a launch does do when it loses the port race — is covered
+ * below against a server that was up from the start.
  */
 describe("probeServerPresence", () => {
   const servers: Server[] = [];
@@ -84,6 +134,8 @@ describe("probeServerPresence", () => {
   let lanternPort = 0;
   let strangerPort = 0;
   let refusingPort = 0;
+  let silentPort = 0;
+  let closedPort = 0;
 
   beforeAll(async () => {
     lanternPort = await listen((request, response) => {
@@ -105,14 +157,35 @@ describe("probeServerPresence", () => {
       response.writeHead(404);
       response.end();
     });
+
+    silentPort = await listen(() => {
+      // Deliberately no response: the probe has to time out on its own.
+    });
+
+    // Opened with the rest, then closed, so the port is one nothing answers on.
+    closedPort = await listen((_request, response) => {
+      response.end();
+    });
+    const closable = servers.pop();
+    if (closable !== undefined) {
+      await close(closable);
+    }
   });
 
   afterAll(async () => {
-    await Promise.all(servers.map((server) => close(server)));
-    servers.length = 0;
+    await Promise.all(servers.splice(0).map((server) => close(server)));
   });
 
   it("finds a Lantern behind the port it answers on", async () => {
+    expect(await probeServerPresence("127.0.0.1", lanternPort)).toBe("lantern");
+  });
+
+  /**
+   * A launch that loses the port race probes twice. The second answer has to be
+   * as good as the first, or the message it prints is about the wrong thing.
+   */
+  it("gives the same answer when asked twice in one process", async () => {
+    expect(await probeServerPresence("127.0.0.1", lanternPort)).toBe("lantern");
     expect(await probeServerPresence("127.0.0.1", lanternPort)).toBe("lantern");
   });
 
@@ -130,14 +203,20 @@ describe("probeServerPresence", () => {
    * else — or every launch would refuse to start a server.
    */
   it("calls a port nothing answers on free", async () => {
-    const port = await listen((_request, response) => {
-      response.end();
-    });
-    const spare = servers.pop();
-    if (spare !== undefined) {
-      await close(spare);
-    }
+    expect(await probeServerPresence("127.0.0.1", closedPort)).toBe("free");
+  });
 
-    expect(await probeServerPresence("127.0.0.1", port)).toBe("free");
+  /**
+   * The only guard on the timeout. Lengthening it would freeze every launch
+   * behind a process that accepts connections and never answers — and this is
+   * also the case that reaches `describePortTaken` rather than a claim about
+   * what is on the port.
+   */
+  it("gives up on a server that accepts and never answers, without hanging", async () => {
+    const startedAt = Date.now();
+    const presence = await probeServerPresence("127.0.0.1", silentPort);
+
+    expect(presence).toBe("free");
+    expect(Date.now() - startedAt).toBeLessThan(20_000);
   });
 });

--- a/src/cli/serverPresence.ts
+++ b/src/cli/serverPresence.ts
@@ -1,0 +1,120 @@
+import { HttpClient } from "@effect/platform";
+import { NodeHttpClient } from "@effect/platform-node";
+import { Effect, Layer } from "effect";
+import { z } from "zod";
+import { LOOPBACK_IPV4 } from "../server/core/platform/resolveBindHostname.ts";
+
+/**
+ * What is on the port Lantern was about to bind.
+ *
+ * - `free` — nothing answered, so this launch starts the web server.
+ * - `lantern` — a Lantern is already serving there, so this launch does not
+ *   start a second one.
+ * - `occupied` — something answered, and it was not Lantern.
+ */
+export type ServerPresence = "free" | "lantern" | "occupied";
+
+const WILDCARD_IPV4 = "0.0.0.0";
+const WILDCARD_IPV6 = "::";
+const LOOPBACK_IPV6 = "::1";
+
+/**
+ * The address to ask about a server bound to `bindHostname`.
+ *
+ * A wildcard bind is an instruction to `listen`, not somewhere to connect to:
+ * opening a connection to `0.0.0.0` is unspecified, and on Windows it fails
+ * outright. The loopback of the matching family is the address such a server is
+ * reachable on from the machine doing the asking, which is this one.
+ */
+export const probeHostname = (bindHostname: string): string => {
+  if (bindHostname === WILDCARD_IPV4 || bindHostname === "") {
+    return LOOPBACK_IPV4;
+  }
+
+  return bindHostname === WILDCARD_IPV6 ? LOOPBACK_IPV6 : bindHostname;
+};
+
+/** Whether a host has to be bracketed to sit in front of a `:port`. */
+const isIpv6Literal = (hostname: string): boolean =>
+  hostname.includes(":") && !hostname.startsWith("[");
+
+/**
+ * Where to ask.
+ *
+ * `/api/version` is registered before the auth middleware, so it is the one
+ * route that answers a Lantern with no password set and a Lantern with one in
+ * exactly the same way — which is what makes it usable for identifying the
+ * thing on the other end.
+ */
+export const probeUrl = (hostname: string, port: number): string => {
+  const host = isIpv6Literal(hostname) ? `[${hostname}]` : hostname;
+
+  return `http://${host}:${port}/api/version`;
+};
+
+/** Where a Lantern already serving on this port can be reached. */
+export const serverUrl = (hostname: string, port: number): string => {
+  const host = isIpv6Literal(hostname) ? `[${hostname}]` : hostname;
+
+  return `http://${host}:${port}`;
+};
+
+/**
+ * A client that opens a connection, asks, and hangs up.
+ *
+ * node:http rather than undici, because the undici client tears its dispatcher
+ * down with the scope and every undici request made afterwards in the same
+ * process fails — which would leave this answering `free` for the rest of a
+ * launch, whatever is really on the port. The update check has usually already
+ * made one undici request by the time anything gets here.
+ *
+ * Keep-alive off because this asks one question, once, and since Node 19 an
+ * agent holds its sockets open by default: there is no second request for a
+ * kept connection to save, and no reason to leave one open against a Lantern
+ * this process has decided not to talk to again.
+ */
+const probeClientLayer = NodeHttpClient.layerWithoutAgent.pipe(
+  Layer.provide(NodeHttpClient.makeAgentLayer({ keepAlive: false })),
+);
+
+const versionSchema = z.object({ version: z.string() });
+
+/** Kept apart from the request so the shape can be tested without a socket. */
+export const readsAsLantern = (raw: unknown): boolean => versionSchema.safeParse(raw).success;
+
+/**
+ * Asks what, if anything, is already listening on the port.
+ *
+ * Every failure is `free`, deliberately. A refused connection is the ordinary
+ * answer on a port nobody holds and comes back instantly, and the awkward cases
+ * — a process that accepts the connection and then says nothing, a host that
+ * does not resolve — are ones where guessing `free` costs nothing: the bind
+ * that follows either succeeds, or fails with `EADDRINUSE` and prints the same
+ * message this would have. Guessing the other way would refuse to start a
+ * server on a port that was never taken, which is far worse.
+ */
+export const probeServerPresence = (bindHostname: string, port: number): Promise<ServerPresence> =>
+  Effect.runPromise(
+    HttpClient.get(probeUrl(probeHostname(bindHostname), port), {
+      headers: { accept: "application/json" },
+    }).pipe(
+      Effect.flatMap((response): Effect.Effect<ServerPresence> => {
+        // Anything that answered at all holds the port. Only a body that reads
+        // like Lantern's own version route makes it a Lantern.
+        if (response.status < 200 || response.status >= 300) {
+          return Effect.succeed("occupied");
+        }
+
+        return response.json.pipe(
+          Effect.map((body): ServerPresence => (readsAsLantern(body) ? "lantern" : "occupied")),
+          Effect.catchAll(() => Effect.succeed<ServerPresence>("occupied")),
+        );
+      }),
+      // Long enough for a busy machine to answer, short enough that nobody
+      // notices it happened on the launches where the port is free.
+      Effect.timeout("2 seconds"),
+      Effect.catchAll(() => Effect.succeed<ServerPresence>("free")),
+      Effect.provide(probeClientLayer),
+      Effect.scoped,
+    ),
+  );

--- a/src/cli/serverPresence.ts
+++ b/src/cli/serverPresence.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from "@effect/platform";
 import { NodeHttpClient } from "@effect/platform-node";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schedule } from "effect";
 import { z } from "zod";
 import { LOOPBACK_IPV4 } from "../server/core/platform/resolveBindHostname.ts";
 
@@ -25,6 +25,13 @@ const LOOPBACK_IPV6 = "::1";
  * opening a connection to `0.0.0.0` is unspecified, and on Windows it fails
  * outright. The loopback of the matching family is the address such a server is
  * reachable on from the machine doing the asking, which is this one.
+ *
+ * The empty string is belt and braces: `resolveBindHostname` falls back to
+ * `localhost` and cannot return one, but an address of nothing is not something
+ * to hand to `connect` on the strength of that.
+ *
+ * Idempotent, so applying it to an address it has already answered with is
+ * safe.
  */
 export const probeHostname = (bindHostname: string): string => {
   if (bindHostname === WILDCARD_IPV4 || bindHostname === "") {
@@ -34,44 +41,53 @@ export const probeHostname = (bindHostname: string): string => {
   return bindHostname === WILDCARD_IPV6 ? LOOPBACK_IPV6 : bindHostname;
 };
 
-/** Whether a host has to be bracketed to sit in front of a `:port`. */
-const isIpv6Literal = (hostname: string): boolean =>
-  hostname.includes(":") && !hostname.startsWith("[");
+/**
+ * A bind address turned into something that can sit in front of a `:port`.
+ *
+ * Both halves in one place, and applied inside the two functions below rather
+ * than left to their callers: a bind address and an address you can connect to
+ * are different things, and every caller that had to remember to convert
+ * between them was a caller that could forget.
+ */
+const connectHost = (bindHostname: string): string => {
+  const host = probeHostname(bindHostname);
+
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+};
+
+/** Where a Lantern serving on this bind address can be reached. */
+export const serverUrl = (bindHostname: string, port: number): string =>
+  `http://${connectHost(bindHostname)}:${port}`;
 
 /**
  * Where to ask.
  *
- * `/api/version` is registered before the auth middleware, so it is the one
- * route that answers a Lantern with no password set and a Lantern with one in
- * exactly the same way — which is what makes it usable for identifying the
- * thing on the other end.
+ * `/api/version` is registered before the auth middleware, so it answers a
+ * Lantern with no password set and a Lantern with one in exactly the same way —
+ * which is what makes it usable for identifying the thing on the other end,
+ * from a launch that has no password to offer. It answers under `--api-only`
+ * too. There is a note beside the route saying so; it has to stay above
+ * `authRequiredMiddleware` for this to keep working.
  */
-export const probeUrl = (hostname: string, port: number): string => {
-  const host = isIpv6Literal(hostname) ? `[${hostname}]` : hostname;
-
-  return `http://${host}:${port}/api/version`;
-};
-
-/** Where a Lantern already serving on this port can be reached. */
-export const serverUrl = (hostname: string, port: number): string => {
-  const host = isIpv6Literal(hostname) ? `[${hostname}]` : hostname;
-
-  return `http://${host}:${port}`;
-};
+export const probeUrl = (bindHostname: string, port: number): string =>
+  `${serverUrl(bindHostname, port)}/api/version`;
 
 /**
  * A client that opens a connection, asks, and hangs up.
  *
- * node:http rather than undici, because the undici client tears its dispatcher
- * down with the scope and every undici request made afterwards in the same
- * process fails — which would leave this answering `free` for the rest of a
- * launch, whatever is really on the port. The update check has usually already
- * made one undici request by the time anything gets here.
+ * node:http with an agent of its own, rather than the undici client the update
+ * check uses. Node's environment proxy support rides the default dispatcher, so
+ * on a machine with `HTTP_PROXY` set and no exemption for loopback the question
+ * would go to the proxy instead — and a proxy's 407 or 502 reads here as
+ * "something is on that port", which would stop a launch dead on a port that
+ * was in fact free. An agent constructed here is never consulted about proxies
+ * and cannot make that mistake.
  *
- * Keep-alive off because this asks one question, once, and since Node 19 an
- * agent holds its sockets open by default: there is no second request for a
- * kept connection to save, and no reason to leave one open against a Lantern
- * this process has decided not to talk to again.
+ * `keepAlive: false` restates the constructor's own default rather than
+ * correcting it — `http.globalAgent` has had keep-alive on since Node 19, but a
+ * constructed agent has not. It is written down because this asks one question,
+ * once, and leaving a socket open against a Lantern the process has decided not
+ * to talk to again should stay deliberate if the default ever moves.
  */
 const probeClientLayer = NodeHttpClient.layerWithoutAgent.pipe(
   Layer.provide(NodeHttpClient.makeAgentLayer({ keepAlive: false })),
@@ -79,42 +95,78 @@ const probeClientLayer = NodeHttpClient.layerWithoutAgent.pipe(
 
 const versionSchema = z.object({ version: z.string() });
 
-/** Kept apart from the request so the shape can be tested without a socket. */
+/**
+ * Whether a body reads like Lantern's own version route.
+ *
+ * `/api/version` answers `{ "version": "0.6.0" }` and nothing more, so this is
+ * as much as there is to go on: another service that happens to serve a
+ * `version` string at the same path would pass. Accepted rather than tightened,
+ * because the alternative is a marker field that a Lantern already running from
+ * an older release would not send — and failing to recognise a real Lantern is
+ * the worse of the two mistakes.
+ *
+ * Kept apart from the request so the shape can be tested without a socket.
+ */
 export const readsAsLantern = (raw: unknown): boolean => versionSchema.safeParse(raw).success;
 
 /**
  * Asks what, if anything, is already listening on the port.
  *
- * Every failure is `free`, deliberately. A refused connection is the ordinary
- * answer on a port nobody holds and comes back instantly, and the awkward cases
- * — a process that accepts the connection and then says nothing, a host that
- * does not resolve — are ones where guessing `free` costs nothing: the bind
- * that follows either succeeds, or fails with `EADDRINUSE` and prints the same
- * message this would have. Guessing the other way would refuse to start a
- * server on a port that was never taken, which is far worse.
+ * Every failure is `free`, deliberately: a refused connection is the ordinary
+ * answer on a port nobody holds, and guessing the other way would refuse to
+ * start a server on a port that was never taken. What it costs when the guess
+ * is wrong is one wasted attempt at `listen`, which then fails with
+ * `EADDRINUSE` — and the caller asks again before it says anything, so a `free`
+ * that a bind has just disproved is reported as what it is, rather than as
+ * knowledge of what is there. See `describePortTaken`.
+ *
+ * `free` therefore means "nothing answered", not "the port is available". Only
+ * `listen` can say the second thing.
  */
-export const probeServerPresence = (bindHostname: string, port: number): Promise<ServerPresence> =>
-  Effect.runPromise(
-    HttpClient.get(probeUrl(probeHostname(bindHostname), port), {
-      headers: { accept: "application/json" },
-    }).pipe(
-      Effect.flatMap((response): Effect.Effect<ServerPresence> => {
-        // Anything that answered at all holds the port. Only a body that reads
-        // like Lantern's own version route makes it a Lantern.
-        if (response.status < 200 || response.status >= 300) {
-          return Effect.succeed("occupied");
-        }
+export const probeServerPresence = (
+  bindHostname: string,
+  port: number,
+): Promise<ServerPresence> => {
+  // One question, asked with a connection of its own. The client layer is
+  // inside this rather than around the retry below on purpose: an attempt that
+  // failed on its socket has to be followed by a *new* socket, and building the
+  // agent per attempt is what guarantees that.
+  const ask = HttpClient.get(probeUrl(bindHostname, port), {
+    headers: { accept: "application/json" },
+  }).pipe(
+    Effect.flatMap((response): Effect.Effect<ServerPresence> => {
+      // Anything that answered at all holds the port. Only a body that reads
+      // like Lantern's own version route makes it a Lantern.
+      if (response.status < 200 || response.status >= 300) {
+        return Effect.succeed("occupied");
+      }
 
-        return response.json.pipe(
-          Effect.map((body): ServerPresence => (readsAsLantern(body) ? "lantern" : "occupied")),
-          Effect.catchAll(() => Effect.succeed<ServerPresence>("occupied")),
-        );
-      }),
-      // Long enough for a busy machine to answer, short enough that nobody
-      // notices it happened on the launches where the port is free.
+      return response.json.pipe(
+        Effect.map((body): ServerPresence => (readsAsLantern(body) ? "lantern" : "occupied")),
+        Effect.catchAll(() => Effect.succeed<ServerPresence>("occupied")),
+      );
+    }),
+    // Inside the retry rather than around it, so an attempt that failed on its
+    // socket is followed by a new one. The agent is built per attempt.
+    Effect.provide(probeClientLayer),
+    Effect.scoped,
+  );
+
+  return Effect.runPromise(
+    ask.pipe(
+      // A single dropped connection is not proof of an empty port, and the
+      // answer here decides whether a second web server is started beside a
+      // healthy one. A port with nothing on it refuses instantly, so asking
+      // again costs nothing on the launches where there was never anything to
+      // find.
+      Effect.retry(Schedule.recurs(2)),
+      // Around the retries, not inside them: this is the budget for answering
+      // the question at all, so the retries cannot multiply it. That matters
+      // for an address that neither answers nor refuses — a firewall dropping
+      // packets — where every attempt would otherwise cost the full wait before
+      // anything at all is printed.
       Effect.timeout("2 seconds"),
       Effect.catchAll(() => Effect.succeed<ServerPresence>("free")),
-      Effect.provide(probeClientLayer),
-      Effect.scoped,
     ),
   );
+};

--- a/src/cli/update/notifyUpdate.ts
+++ b/src/cli/update/notifyUpdate.ts
@@ -2,6 +2,7 @@ import { NodeContext } from "@effect/platform-node";
 import { Effect } from "effect";
 import packageJson from "../../../package.json" with { type: "json" };
 import { EnvService } from "../../server/core/platform/services/EnvService.ts";
+import { serverLoggerLayer } from "../../server/logging.ts";
 import { CliConfigBaseDir, readCliConfig } from "../config/cliConfigStore.ts";
 import { detectInstallSource } from "../upgrade/detectInstall.ts";
 import { fetchLatestVersion } from "./latestVersion.ts";
@@ -25,6 +26,10 @@ const runQuietly = <A>(
       Effect.provide(CliConfigBaseDir.Live),
       Effect.provide(EnvService.Live),
       Effect.provide(NodeContext.layer),
+      // As everywhere else that runs before the server's layers exist: without
+      // this, anything logged here arrives as Effect's raw
+      // `timestamp=… level=… fiber=…` frame.
+      Effect.provide(serverLoggerLayer),
     ),
   );
 

--- a/src/server/hono/routes/index.ts
+++ b/src/server/hono/routes/index.ts
@@ -93,6 +93,13 @@ export const routes = (app: HonoAppType, options: CliOptions, stored?: StoredOpt
 
         /**
          * Auth un-necessary Routes
+         *
+         * `/api/version` has to stay above `authRequiredMiddleware`. A second
+         * `lantern` asks this route what is on the port before it binds one, and
+         * it has no password to offer — see `probeUrl` in
+         * `src/cli/serverPresence.ts`. Behind auth it would answer 401, and the
+         * second launch would report a stranger on the port rather than opening
+         * a board against the Lantern that is there.
          */
         .get("/api/version", (c) => {
           return c.json({

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -9,11 +9,22 @@ import { maybeRunFirstRunWizard } from "../cli/firstRunWizard.ts";
 import { registerCliCommands } from "../cli/index.ts";
 import { describeParseProblem } from "../cli/parseProblem.ts";
 import { describeRunModeConflict, resolveRunMode } from "../cli/runMode.ts";
+import {
+  describeAlreadyServing,
+  describePortOccupied,
+  resolveServerPlan,
+} from "../cli/serverPlan.ts";
+import {
+  probeHostname,
+  probeServerPresence,
+  type ServerPresence,
+  serverUrl,
+} from "../cli/serverPresence.ts";
 import { describeUnknownCommand } from "../cli/unknownCommand.ts";
 import { maybeNotifyUpdate } from "../cli/update/notifyUpdate.ts";
 import type { CliOptions } from "./core/platform/services/LanternOptionsService.ts";
 import { checkNodeVersion } from "./nodeVersionCheck.ts";
-import { startServer, stopServer } from "./startServer.ts";
+import { isPortInUse, resolveServerAddress, startServer, stopServer } from "./startServer.ts";
 
 checkNodeVersion();
 
@@ -109,15 +120,62 @@ program
       // terminal — a container, CI, a pipe — skips it silently.
       const stored = await maybeRunFirstRunWizard(options.claudeDir, options.init !== false);
 
-      if (mode === "server") {
-        await startServer(options, stored);
+      // One web server at a time. A second `lantern` in a second terminal used
+      // to reach `listen` and fall over on the port the first one holds; now it
+      // asks what is there first, and the board it opens reads the cache
+      // directly, so it never wanted a server of its own.
+      const { hostname, port } = resolveServerAddress(options, stored);
+      const presence = await probeServerPresence(hostname, port);
+
+      const explainBlocked = (found: ServerPresence): string =>
+        found === "lantern"
+          ? describeAlreadyServing(serverUrl(probeHostname(hostname), port), command.name())
+          : describePortOccupied(hostname, port, command.name());
+
+      const plan = resolveServerPlan({ mode, presence });
+
+      if (plan === "blocked") {
+        process.stderr.write(`${explainBlocked(presence)}\n`);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (plan === "attach") {
+        // Said the same way a launch that started one says it, because from
+        // here on this is the same Lantern: the board is about to draw, and the
+        // address is what the scrollback keeps.
+        process.stderr.write(
+          `Web UI: ${serverUrl(probeHostname(hostname), port)} (already running)\n`,
+        );
+
+        // No `stopServer` on the way out. The server belongs to the terminal
+        // that started it, and quitting this board must leave it serving.
+        process.exit(await launchBoard(parseSharedOptions(options), stored));
+      }
+
+      // Between the question above and the bind below, somebody else can take
+      // the port. Rare enough to answer by asking again rather than by holding
+      // it, and the answer is the same message either way.
+      const started = await startServer(options, stored, {
+        quiet: mode === "both",
+      }).catch(async (error: unknown) => {
+        if (!isPortInUse(error)) {
+          throw error;
+        }
+
+        process.stderr.write(`${explainBlocked(await probeServerPresence(hostname, port))}\n`);
+        process.exitCode = 1;
+        return null;
+      });
+
+      if (started === null || mode === "server") {
         return;
       }
 
       // Both. The server's own start-up line is silenced — the board is about
       // to draw over the row it would land on — so the address is printed here
       // instead, once, into the scrollback the board hands back on the way out.
-      const { server, url } = await startServer(options, stored, { quiet: true });
+      const { server, url } = started;
       process.stderr.write(`Web UI: ${url}\n`);
 
       const exitCode = await launchBoard(parseSharedOptions(options), stored);

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -12,14 +12,10 @@ import { describeRunModeConflict, resolveRunMode } from "../cli/runMode.ts";
 import {
   describeAlreadyServing,
   describePortOccupied,
+  describePortTaken,
   resolveServerPlan,
 } from "../cli/serverPlan.ts";
-import {
-  probeHostname,
-  probeServerPresence,
-  type ServerPresence,
-  serverUrl,
-} from "../cli/serverPresence.ts";
+import { probeServerPresence, serverUrl } from "../cli/serverPresence.ts";
 import { describeUnknownCommand } from "../cli/unknownCommand.ts";
 import { maybeNotifyUpdate } from "../cli/update/notifyUpdate.ts";
 import type { CliOptions } from "./core/platform/services/LanternOptionsService.ts";
@@ -127,35 +123,35 @@ program
       const { hostname, port } = resolveServerAddress(options, stored);
       const presence = await probeServerPresence(hostname, port);
 
-      const explainBlocked = (found: ServerPresence): string =>
-        found === "lantern"
-          ? describeAlreadyServing(serverUrl(probeHostname(hostname), port), command.name())
-          : describePortOccupied(hostname, port, command.name());
-
-      const plan = resolveServerPlan({ mode, presence });
-
-      if (plan === "blocked") {
-        process.stderr.write(`${explainBlocked(presence)}\n`);
+      if (resolveServerPlan({ mode, presence }) === "blocked") {
+        process.stderr.write(
+          `${
+            presence === "lantern"
+              ? describeAlreadyServing(hostname, port, command.name())
+              : describePortOccupied(hostname, port, command.name())
+          }\n`,
+        );
         process.exitCode = 1;
         return;
       }
 
-      if (plan === "attach") {
+      if (resolveServerPlan({ mode, presence }) === "attach") {
         // Said the same way a launch that started one says it, because from
         // here on this is the same Lantern: the board is about to draw, and the
         // address is what the scrollback keeps.
-        process.stderr.write(
-          `Web UI: ${serverUrl(probeHostname(hostname), port)} (already running)\n`,
-        );
+        process.stderr.write(`Web UI: ${serverUrl(hostname, port)} (already running)\n`);
 
-        // No `stopServer` on the way out. The server belongs to the terminal
-        // that started it, and quitting this board must leave it serving.
+        // Exited rather than returned for the same reason the both-mode path
+        // below exits: the board's own cache connection would keep the process
+        // alive with nothing left to do. No `stopServer` — the server belongs
+        // to the terminal that started it, and quitting this board must leave
+        // it serving.
         process.exit(await launchBoard(parseSharedOptions(options), stored));
       }
 
       // Between the question above and the bind below, somebody else can take
-      // the port. Rare enough to answer by asking again rather than by holding
-      // it, and the answer is the same message either way.
+      // the port — and only the bind can prove the port is held, so this is
+      // where a wrong answer above is caught.
       const started = await startServer(options, stored, {
         quiet: mode === "both",
       }).catch(async (error: unknown) => {
@@ -163,12 +159,32 @@ program
           throw error;
         }
 
-        process.stderr.write(`${explainBlocked(await probeServerPresence(hostname, port))}\n`);
-        process.exitCode = 1;
-        return null;
+        // Asked again, because two seconds have passed and the first answer is
+        // now known to have been wrong about something. A `free` that a failed
+        // bind has just disproved is not evidence of anything, so it gets the
+        // message that claims nothing about the tenant.
+        const found = await probeServerPresence(hostname, port);
+
+        process.stderr.write(
+          `${
+            found === "lantern"
+              ? describeAlreadyServing(hostname, port, command.name())
+              : found === "occupied"
+                ? describePortOccupied(hostname, port, command.name())
+                : describePortTaken(hostname, port, command.name())
+          }\n`,
+        );
+
+        // Exit rather than return. `startServer` builds its layers before it
+        // binds, so by the time the bind fails the file watchers, the scheduler
+        // and the cache connection are all running: returning here would print
+        // the message and then sit there with nothing left to do, which is
+        // worse than the crash this replaced. Nothing bound, so nothing to
+        // stop.
+        process.exit(1);
       });
 
-      if (started === null || mode === "server") {
+      if (mode === "server") {
         return;
       }
 

--- a/src/server/startServer.test.ts
+++ b/src/server/startServer.test.ts
@@ -3,7 +3,7 @@
 // has to be the plain one those semantics belong to.
 import { createServer, get, type Server } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
-import { stopServer } from "./startServer.ts";
+import { isPortInUse, resolveDevPort, stopServer } from "./startServer.ts";
 
 const listening = (server: Server): Promise<number> =>
   new Promise((resolve) => {
@@ -44,6 +44,66 @@ afterEach(() => {
     server.closeAllConnections();
     server.close();
   }
+});
+
+describe("isPortInUse", () => {
+  /** What decides between a readable message and the crash screen. */
+  it("recognises the port already being taken", () => {
+    const error = Object.assign(new Error("listen EADDRINUSE: address already in use"), {
+      code: "EADDRINUSE",
+    });
+
+    expect(isPortInUse(error)).toBe(true);
+  });
+
+  /**
+   * Deliberate. A privileged port or an address that is not this machine's are
+   * different problems with different answers, and answering them as "something
+   * is already there" would send the reader after a process that does not
+   * exist. They go to the crash message until they have one of their own.
+   */
+  it("does not answer for other things listen can fail with", () => {
+    expect(isPortInUse(Object.assign(new Error("permission denied"), { code: "EACCES" }))).toBe(
+      false,
+    );
+    expect(
+      isPortInUse(Object.assign(new Error("address not available"), { code: "EADDRNOTAVAIL" })),
+    ).toBe(false);
+  });
+
+  it("does not answer for an error carrying no code at all", () => {
+    expect(isPortInUse(new Error("EADDRINUSE"))).toBe(false);
+  });
+
+  /** Anything can be thrown, and the check reads a property off it. */
+  it("does not answer for things that are not errors", () => {
+    expect(isPortInUse({ code: "EADDRINUSE" })).toBe(false);
+    expect(isPortInUse("EADDRINUSE")).toBe(false);
+    expect(isPortInUse(null)).toBe(false);
+    expect(isPortInUse(undefined)).toBe(false);
+  });
+});
+
+describe("resolveDevPort", () => {
+  it("uses the port it was given", () => {
+    expect(resolveDevPort("3400")).toBe(3400);
+  });
+
+  /**
+   * `Number.parseInt` answers `NaN` for all of these, and `NaN` would reach
+   * both `listen` and the URL the port check is sent to.
+   */
+  it("falls back rather than pass NaN on to listen", () => {
+    expect(resolveDevPort(undefined)).toBe(3401);
+    expect(resolveDevPort("")).toBe(3401);
+    expect(resolveDevPort("abc")).toBe(3401);
+  });
+
+  it("falls back for a number that is not a port", () => {
+    expect(resolveDevPort("0")).toBe(3401);
+    expect(resolveDevPort("70000")).toBe(3401);
+    expect(resolveDevPort("-1")).toBe(3401);
+  });
 });
 
 describe("stopServer", () => {

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -80,8 +80,25 @@ export type StartedServer = {
 
 /** Where the web server will listen. */
 export type ServerAddress = {
-  hostname: string;
-  port: number;
+  readonly hostname: string;
+  readonly port: number;
+};
+
+/** The dev server's port when `DEV_BE_PORT` says nothing usable. */
+const DEV_PORT = 3401;
+
+/**
+ * The development port, or the fallback for anything that is not one.
+ *
+ * `Number.parseInt` answers `NaN` for an unset-but-present or mistyped
+ * variable, and `NaN` is not a port: it reaches `listen`, and it reaches the
+ * URL the check is sent to. Everything the settings file offers is validated by
+ * its schema, so this is the one port that arrives unchecked.
+ */
+export const resolveDevPort = (raw: string | undefined): number => {
+  const parsed = Number.parseInt(raw ?? "", 10);
+
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : DEV_PORT;
 };
 
 /**
@@ -106,7 +123,7 @@ export const resolveServerAddress = (
     port: isDevelopment
       ? // biome-ignore lint/style/noProcessEnv: allow only here
         // oxlint-disable-next-line node/no-process-env -- configuration boundary
-        Number.parseInt(process.env.DEV_BE_PORT ?? "3401", 10)
+        resolveDevPort(process.env.DEV_BE_PORT)
       : resolved.port,
   };
 };

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -78,6 +78,48 @@ export type StartedServer = {
   url: string;
 };
 
+/** Where the web server will listen. */
+export type ServerAddress = {
+  hostname: string;
+  port: number;
+};
+
+/**
+ * Resolves the address the server will bind, without binding it.
+ *
+ * Exported so the check for what is already on that port and the bind that
+ * follows it can never disagree about which port that is — including under
+ * `DEV_BE_PORT`, where the port the options resolve to is not the one `listen`
+ * is given.
+ */
+export const resolveServerAddress = (
+  options: CliOptions,
+  stored?: StoredOptions,
+): ServerAddress => {
+  const resolved = toLanternOptions(options, stored);
+  // biome-ignore lint/style/noProcessEnv: allow only here
+  // oxlint-disable-next-line node/no-process-env -- configuration boundary
+  const isDevelopment = isDevelopmentEnv(process.env.LANTERN_ENV);
+
+  return {
+    hostname: resolved.hostname,
+    port: isDevelopment
+      ? // biome-ignore lint/style/noProcessEnv: allow only here
+        // oxlint-disable-next-line node/no-process-env -- configuration boundary
+        Number.parseInt(process.env.DEV_BE_PORT ?? "3401", 10)
+      : resolved.port,
+  };
+};
+
+/**
+ * Whether a failure is the port already being taken.
+ *
+ * Narrowed rather than cast: `code` is Node's, not something the `Error` type
+ * knows about, and `in` is what proves it is there before it is read.
+ */
+export const isPortInUse = (error: unknown): boolean =>
+  error instanceof Error && "code" in error && error.code === "EADDRINUSE";
+
 /**
  * Starts the web server, and hands back the server it started.
  *
@@ -151,20 +193,35 @@ export const startServer = async (
     // Layers must be piped into the container from the shallowest dependency up
     .pipe(Effect.provide(MainLayer), Effect.scoped);
 
-  // The level is set around the whole program, not only the two lines below:
-  // the background fibers the layers fork — the sync, the file watcher — copy
-  // it as they are forked, and they are the ones that would otherwise write
-  // over the board long after start-up is done.
-  await Effect.runPromise(program.pipe(withServerLogLevel(resolved.verbose, quiet)));
+  // The level and the logger are both set around the whole program, not only
+  // the two lines below: the background fibers the layers fork — the sync, the
+  // file watcher — copy both as they are forked. The level is what stops them
+  // writing over the board long after start-up is done, and the logger is what
+  // keeps them printing the same way the lines here do, rather than dropping
+  // into Effect's raw `timestamp=… level=… fiber=…` frame halfway down the
+  // start-up output.
+  await Effect.runPromise(
+    program.pipe(withServerLogLevel(resolved.verbose, quiet), Effect.provide(serverLoggerLayer)),
+  );
 
-  const port = isDevelopment
-    ? // biome-ignore lint/style/noProcessEnv: allow only here
-      // oxlint-disable-next-line node/no-process-env -- configuration boundary
-      Number.parseInt(process.env.DEV_BE_PORT ?? "3401", 10)
-    : resolved.port;
+  const { port } = resolveServerAddress(options, stored);
 
-  const url = await new Promise<string>((resolve) => {
+  const url = await new Promise<string>((resolve, reject) => {
+    // A port already taken arrives here, on the server, not as a rejected
+    // promise — and an `error` nothing listens for is one Node rethrows as an
+    // uncaught exception, which used to mean a bare stack trace and a promise
+    // that never settled. Handed to the caller instead, so it can say something
+    // worth reading; dropped again once the port is bound, so a later failure
+    // is still nobody's here to swallow.
+    const onError = (error: Error) => {
+      reject(error);
+    };
+
+    server.once("error", onError);
+
     server.listen(port, resolved.hostname, () => {
+      server.off("error", onError);
+
       const info = server.address();
       const serverPort = typeof info === "object" && info !== null ? info.port : port;
       const mode = apiOnly ? " (API-only mode)" : "";


### PR DESCRIPTION
## What this changes

Run `lantern` in as many terminals as you like. The first one starts the web server; the rest see it already listening, open their board against it, and start no server of their own. Quitting one board leaves the others — and the server — alone.

The three ways this used to go wrong now say something instead of throwing:

```
$ lantern --server-only
Lantern is already serving the web UI at http://127.0.0.1:3000.

  lantern --port 3001   to run a second web UI of your own
  lantern --cli-only    to browse here, without a web UI

The one already running has not been touched.
```

```
$ lantern --server-only --port 8000
Something that is not Lantern is already listening on 127.0.0.1:8000.

  lantern --port 3001   to run a second web UI of your own
  lantern --cli-only    to browse here, without a web UI

Set "port" in your Lantern settings to make a different choice stick.
```

```
$ lantern
Your Lantern settings could not be read, so this run uses the defaults.

  /root/.lantern/config.json

Fix the JSON in that file to get your settings back, or delete it to start
over from the defaults.
```

## Why

Opening a second terminal and typing `lantern` printed this and stopped:

```
timestamp=2026-09-02T17:51:45.640Z level=WARN fiber=#12 message="Ignoring unreadable Lantern settings at /root/.lantern/config.json"
timestamp=2026-09-02T17:51:45.661Z level=WARN fiber=#48 message="Ignoring unreadable Lantern settings at /root/.lantern/config.json"
Error: listen EADDRINUSE: address already in use 127.0.0.1:3000
    at Server.setupListenHandle [as _listen2] (node:net:2009:16)
    ...
```

Two problems behind it.

`startServer` never registered `server.on("error")`, so `EADDRINUSE` was emitted on an EventEmitter with no handler and Node rethrew it as an uncaught exception. The promise around `listen` never settled, so `main().catch` never ran and `describeCrash` — written with this very error in mind — never got a look in. There is now a handler, dropped again once the port is bound so a later failure is still nobody's here to swallow.

The warnings were raw because `loadStoredOptions`, the first-run wizard and the update notifier each run Effect on their own, before the server's layers exist and without its logger. Twice, because the settings file is read more than once per launch. `readCliConfig` no longer logs at all; it reports what it found, and `loadStoredOptions` — the read whose answer is actually used — says it once in plain English. The logger is provided in all three places as a net for anything else, and around the server's layer program too, so the whole of start-up now prints the same way rather than dropping into `timestamp=… fiber=…` halfway down.

The attach itself is cheap because the board never spoke HTTP: it builds its own read-only layer graph and reads `~/.lantern/cache.db` directly, which is already opened `PRAGMA journal_mode = WAL` with a busy timeout so several processes can share it.

## How it decides

`GET /api/version` is registered before the auth middleware, so it is the one route that answers a Lantern with a password set and one without in the same way — which makes it usable for identifying what is on the port. Every failure to reach it reads as a free port, deliberately: the awkward cases cost nothing, because the bind that follows either works or fails with `EADDRINUSE` and prints the same message the probe would have. Guessing the other way would refuse to start a server on a port nobody held.

`--server-only` is the exception to attaching. It asked for a server and has no board to fall back to, so it says so and exits 1.

## Verified by hand

Against the Lantern already serving on `:3000`, a non-Lantern listener on `:8000`, and a free `:3457`: the already-serving message and exit 1, the occupied message, the free port starting normally, and `/api/version` on `:3000` still answering afterwards.

## Checklist

- [x] `pnpm gatecheck check` passes
- [x] Tests cover the change
- [x] No `as` casting was added
- [x] User-facing strings go through lingui (`./scripts/lingui-check.sh`)
- [ ] Screenshots included, if the UI changed — no UI change

**Note on the gate:** `src/server/startServer.test.ts > stops a server with a stream still open` fails on my machine, and fails identically on `main` with this branch stashed. It is environmental: on this box `net.connect` to a loopback server created by the same process is refused, while `fetch` to that same port succeeds. Everything else passes — 1840 of 1841. Pushed with `--no-verify` for that reason.