### PR TITLE
chore: typecheck and lint the scripts directory

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -252,6 +252,17 @@
       }
     },
     {
+      // Build and release scripts are plain Node programs run by pnpm, not part
+      // of the Effect runtime, so the node: builtins they are steered away from
+      // in src/ are the correct tool here. They also talk to the operator on
+      // stdout, which is the whole point of a release script.
+      "files": ["scripts/**"],
+      "rules": {
+        "no-restricted-imports": "off",
+        "no-console": "off"
+      }
+    },
+    {
       "files": ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx"],
       "rules": {
         "no-restricted-imports": "off",
@@ -389,7 +400,14 @@
     "src/lib/i18n/locales/*/messages.json",
     "src/routeTree.gen.ts",
     "e2e/**",
-    "scripts/**",
+    // The untyped JavaScript under scripts/ — every parameter is an implicit
+    // any, so the type-aware rules report a little over a hundred violations
+    // that are all the same missing annotation. Named one at a time rather than
+    // as `scripts/**`, so a new script is linted by default and this list is
+    // what shrinks as they gain JSDoc types.
+    "scripts/lints/**",
+    "scripts/lingui-sort.js",
+    "scripts/put-transtation.js",
     "**/*.config.*"
   ],
   "options": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
       }
     ]
   },
-  "include": ["src", "tsdown.config.ts"],
+  "include": ["src", "tsdown.config.ts", "scripts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What

`tsconfig.json` included only `["src", "tsdown.config.ts"]`, and `.oxlintrc.json` ignored `scripts/**`. Nothing in `scripts/` was typechecked or linted by anything.

That is the gap behind the last two dependency PRs. `@types/inquirer` sat five majors stale without a single check noticing (#97), and the inquirer 13 → 14 bump (#91) had to be verified by hand, because `pnpm typecheck` passing said nothing about `scripts/release.ts` — the only file that imports inquirer.

## The change

`scripts` joins the tsconfig `include`. This costs nothing: the directory typechecks clean as it stands, so this is coverage without cleanup.

The lint half turned out to depend on the typecheck half. Unignoring `scripts/` while it was still outside the tsconfig project produced five `typescript(no-unsafe-*)` reports in `release.ts` on values oxlint could not resolve types for; once the directory is in the project those resolve and the reports disappear. What remains is `no-restricted-imports` steering `node:child_process`, `node:fs` and `node:path` toward `@effect/platform` — the right rule for `src/`, the wrong one for a standalone Node program run by pnpm. So `scripts/**` gets an override turning that off, plus `no-console`, since talking to the operator on stdout is what a release script does.

## What stays ignored, and why

The untyped JavaScript — `scripts/lints/**`, `scripts/lingui-sort.js`, `scripts/put-transtation.js`. Every callback parameter is an implicit `any`, so the type-aware rules report 117 violations across them that are all the same missing annotation:

| File | Reports |
| --- | --- |
| `scripts/lints/conventions.js` | 67 |
| `scripts/lints/conventions.test.js` | 38 |
| `scripts/lingui-sort.js` | 12 |
| `scripts/put-transtation.js` | 7 (9 once types resolve) |

Fixing them means adding JSDoc types to the oxlint plugin API, which is its own piece of work and does not belong in a PR about coverage. They are listed one file at a time rather than as `scripts/**`, so a script added tomorrow is linted by default and this list is what shrinks.

Separately, enabling `checkJs` would add 25 `TS7006`/`TS7053` errors on the same files. Also deferred, for the same reason.

## Testing

Both halves were checked by mutation rather than assumed — neither would have been caught before this change:

- A bad annotation appended to `release.ts` now fails `tsgo`: `scripts/release.ts(288,7): error TS2322: Type 'string' is not assignable to type 'number'.`
- `debugger`, `==` and a constant condition in `release.ts` are now reported by oxlint (`no-debugger`, `eqeqeq`, `no-constant-condition`).

Full suite on the final state: `pnpm typecheck` clean, `oxlint .` exit 0, `pnpm vitest run` 195 files / 1889 tests passing, `./scripts/lingui-check.sh` clean.